### PR TITLE
Add configuration for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+BasedOnStyle: LLVM
+Language: C
+IndentWidth: 2
+ContinuationIndentWidth: 2
+ColumnLimit: 80
+PointerAlignment: Right
+BreakBeforeBraces: Linux
+UseTab: Never
+MaxEmptyLinesToKeep: 1
+SpaceBeforeParens: ControlStatements
+AllowShortIfStatementsOnASingleLine: Never
+IndentCaseLabels: true
+SortIncludes: CaseInsensitive
+IncludeBlocks: Preserve
+SpaceAfterCStyleCast: true
+AlignConsecutiveAssignments: Consecutive
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: OnePerLine
+AlignAfterOpenBracket: Align
+SpaceBeforeAssignmentOperators: true
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 1

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,20 @@
+name: clang-format Check
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+jobs:
+  formatting-check:
+    runs-on: ubuntu-latest
+    name: Formatting Check
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run clang-format style check
+      uses: jidicula/clang-format-action@v4.15.0
+      with:
+        clang-format-version: '20'
+        check-path: 'src'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-symlinks
+    - id: end-of-file-fixer
+    - id: mixed-line-ending
+    - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
     rev: v0.44.0
     hooks:
     - id: markdownlint
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.0
+    hooks:
+    - id: clang-format
+      types_or: [c]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     - id: end-of-file-fixer
     - id: mixed-line-ending
     - id: trailing-whitespace
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+    - id: markdownlint


### PR DESCRIPTION
This fixes #4.

This PR adds the style file `.clang-format` for `clang-format` so we can unify the coding style. Unless you have strong opinion on a particular option, I am inclined to just stick to this for now and amend/add some as we go if we find some absolutely ugly formatting style later. You can find the full list (!) of styling options [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) if you are interested.

I also add basic pre-commit hooks with markdown linting and clang formatting, also a GitHub Action to verify the coding format.  