### PR TITLE
Check style of include files in CI

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,10 +11,15 @@ jobs:
   formatting-check:
     runs-on: ubuntu-latest
     name: Formatting Check
+    strategy:
+      matrix:
+        path:
+          - 'src'
+          - 'include'
     steps:
     - uses: actions/checkout@v4
     - name: Run clang-format style check
       uses: jidicula/clang-format-action@v4.15.0
       with:
         clang-format-version: '20'
-        check-path: 'src'
+        check-path: ${{ matrix.path }}


### PR DESCRIPTION
This PR modifies the GitHub Action for checking code formatting in the `include` directory where the header files are placed.