### PR TITLE
Fix linting issue with README

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+MD024:
+  siblings_only: true

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ mib2h5 -c -d '/rawdata' -r '10x10' -t 300 input.mib
 ```
 
 This will:
+
 - enable Blosc compression
 - store the frames at the dataset key `/rawdata` in the HDF5 file
 - reshape the data to `(10, 10, det_y, det_x)` if there are 100 frames with


### PR DESCRIPTION
This PR fixes two linting issues with the `README.md` file:

- MD024 (Multiple headings with the same content):  Allow duplicated headings if their parents are different
- MD032 (Lists should be surrounded by blank lines): The spacing issue is fixed