### PR TITLE
Add files for initializing hdf5

### DIFF
--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -1,4 +1,5 @@
 #include "hdf5_init.h"
+#include "macros.h"
 #include "utils.h"
 #include <hdf5.h>
 #include <stdio.h>
@@ -13,11 +14,13 @@ void initialize_plist(char *path,
     fprintf(stderr, "Error in creating fcpl in create_file\n");
     return;
   }
+  unsigned long f_blocksize = get_filesystem_block_size(path);
+  printf("block size of filesystem: %ld\n", f_blocksize);
   if ((*fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating fapl in create_file\n");
     return;
   } else {
-    if (H5Pset_alignment(*fapl_id, 1024, 4096) < 0) {
+    if (H5Pset_alignment(*fapl_id, ALIGNMENT_THRESHOLD, f_blocksize) < 0) {
       fprintf(stderr, "Error in H5Pset_alignment\n");
       return;
     }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -1,4 +1,5 @@
 #include "hdf5_init.h"
+#include "utils.h"
 #include <hdf5.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,34 +41,6 @@ void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
     fprintf(stderr, "Error in creating file_id in intialize_file\n");
     return;
   }
-}
-
-hid_t bufsize_to_datatype(int dtype)
-{
-  hid_t datatype;
-  switch (dtype) {
-    case 1: {
-      datatype = H5T_STD_U8LE;
-      break;
-    }
-    case 2: {
-      datatype = H5T_STD_U16LE;
-      break;
-    }
-    case 4: {
-      datatype = H5T_STD_U32LE;
-      break;
-    }
-    case 8: {
-      datatype = H5T_STD_U64LE;
-      break;
-    }
-    default: {
-      fprintf(stderr, "Error in datatype, please check input dtype\n");
-      return;
-    }
-  }
-  return datatype;
 }
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -1,6 +1,4 @@
 #include "hdf5_init.h"
-#include "blosc_filter.h"
-#include <blosc.h>
 #include <hdf5.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -61,7 +59,6 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
   hid_t lcpl = *lcpl_id;
   hid_t dcpl;
   hid_t dapl;
-  unsigned int cd_values[7] = {0};
 
   if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating dcpl\n");

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -3,9 +3,8 @@
 #include <hdf5.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
-void initialize_plist(hid_t *file_id,
+void initialize_plist(char *path,
                       hid_t *fapl_id,
                       hid_t *fcpl_id,
                       hid_t *lcpl_id)

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -33,7 +33,7 @@ void initialize_plist(char *path,
 
 void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
 {
-  if (!filename) {
+  if (filename == NULL) {
     fprintf(stderr, "Empty or other error in filename, please check\n");
   }
 

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -59,8 +59,9 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
                            size_t dim,
                            hsize_t *frame_dim)
 {
-  hid_t dcpl;
-  hid_t dapl;
+  hid_t dcpl     = H5I_INVALID_HID;
+  hid_t dapl     = H5I_INVALID_HID;
+  hid_t datatype = H5I_INVALID_HID;
 
   if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating dcpl\n");
@@ -90,7 +91,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     }
   }
 
-  hid_t datatype = bufsize_to_datatype(dtype);
+  datatype = bufsize_to_datatype(dtype);
 
   if ((*merlin_dataset_id = H5Dcreate2(file, merlin_dataset_name, datatype,
                                        memspace, lcpl, dcpl, dapl)) ==
@@ -98,6 +99,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     fprintf(stderr, "Error in creating merlin_dataset\n");
     goto cleanup;
   }
+
 cleanup:
   if (H5Iis_valid(dcpl))
     H5Pclose(dcpl);

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -103,7 +103,8 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     unsigned int y = frame_dim[1];
     unsigned int x = frame_dim[2];
 
-    if (H5Pset_chunk_cache(dapl, 521, 2 * dtype * y * x, 1.0) < 0) {
+    if (H5Pset_chunk_cache(dapl, 521, NUM_CHUNKS_IN_CACHE * dtype * y * x,
+                           1.0) < 0) {
       fprintf(stderr, "Error in H5Pset)chunk_cache\n");
       return;
     }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -43,19 +43,14 @@ void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
 }
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,
-                           hid_t *file_id,
+                           hid_t file,
                            char *merlin_dataset_name,
                            int dtype,
                            hid_t memspace,
-                           hid_t *lcpl_id,
+                           hid_t lcpl,
                            size_t dim,
-                           hsize_t *frame_dim,
-                           unsigned int compression_level,
-                           unsigned int shuffle,
-                           unsigned int compressor)
+                           hsize_t *frame_dim)
 {
-  hid_t file = *file_id;
-  hid_t lcpl = *lcpl_id;
   hid_t dcpl;
   hid_t dapl;
 

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -1,0 +1,177 @@
+#include "hdf5_init.h"
+#include "blosc_filter.h"
+
+#include <blosc.h>
+#include <hdf5.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+/*
+// functions for debugging
+void check_space_and_storage(hid_t dset) {
+        H5D_space_status_t space_status;
+        hsize_t storage_size;
+
+        status = H5Dget_space_status(dset, &space_status);
+        storage_size = H5Dget_storage_size(dset);
+        printf("Space for dataset has%sbeen allocated. \n", space_status ==
+H5D_SPACE_STATUS_ALLOCATED ? " " : " NOT "); printf("Storage size for dataset is
+: %ld bytes.\n", (long)storage_size);
+}
+*/
+
+// REAL functions
+void initialize_file_and_plist(char *filename,
+                               hid_t *file_id,
+                               hid_t *fapl_id,
+                               hid_t *fcpl_id)
+{
+  unsigned mode = H5F_ACC_TRUNC;
+  char *version, *date;
+
+  if ((*fcpl_id = H5Pcreate(H5P_FILE_CREATE)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating fcpl in create_file\n");
+    return;
+  }
+  if ((*fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating fapl in create_file\n");
+    return;
+  } else {
+    if (H5Pset_alignment(*fapl_id, 1024, 4096) < 0) {
+      fprintf(stderr, "Error in H5Pset_alignment\n");
+      return;
+    }
+  }
+  if ((*file_id = H5Fcreate(filename, mode, *fcpl_id, *fapl_id)) ==
+      H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating file_id in create_file, please check if "
+                    "file already existed\n");
+    return;
+  }
+  if (register_blosc(&version, &date) < 0) {
+    fprintf(stderr, "Error in register_blosc\n");
+    return;
+  } else {
+    printf("Blosc version info: %s (%s)\n", version, date);
+    free(version);
+    free(date);
+  }
+}
+
+void initialize_lcpl(hid_t *lcpl_id)
+{
+  if ((*lcpl_id = H5Pcreate(H5P_LINK_CREATE)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating lcpl in initialize_dataset_plist\n");
+    return;
+  }
+  /*
+  else {
+    if (H5Pset_create_intermediate_group(*lcpl_id, 1) < 0) {
+      fprintf(stderr, "Error in H5Pset_create_intermediate_group\n");
+      return;
+    }
+    if (H5Pset_char_encoding(*lcpl_id, H5T_CSET_UTF8) < 0) {
+      fprintf(stderr, "Error in H5Pset_char_encoding\n");
+      return;
+    }
+  }
+  */
+}
+
+void create_merlin_dataset(hid_t *merlin_dataset_id,
+                           hid_t *file_id,
+                           char *merlin_dataset_name,
+                           int dtype,
+                           hid_t memspace,
+                           hid_t *lcpl_id,
+                           size_t dim,
+                           hsize_t *frame_dim,
+                           unsigned int compression_level,
+                           unsigned int shuffle,
+                           unsigned int compressor)
+{
+  hid_t file = *file_id;
+  hid_t lcpl = *lcpl_id;
+  hid_t dcpl;
+  hid_t dapl;
+  // int fill_value = -1;
+  unsigned int cd_values[7] = {0};
+
+  if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating dcpl\n");
+    return;
+  } else {
+    if (H5Pset_chunk(dcpl, dim, frame_dim) < 0) {
+      fprintf(stderr, "Error in H5Pset_chunk\n");
+      return;
+    }
+    if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
+      fprintf(stderr, "Error in H5Pset_fill_time\n");
+      return;
+    }
+    /*
+    if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill_value) < 0) {
+      fprintf(stderr, "Error in H5Pset_fill_value\n");
+      return;
+    }
+   */
+    cd_values[0] = 0;
+    cd_values[1] = compression_level;
+    cd_values[2] = shuffle;
+    cd_values[3] = 0; // blocksize
+    cd_values[4] = 0; // unused
+    cd_values[5] = 0; // unused
+    cd_values[6] = compressor;
+    if (H5Pset_filter(dcpl, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) <
+        0) {
+      fprintf(stderr, "Error in H5Pset_filter\n");
+      return;
+    }
+  }
+
+  if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating dapl_id\n");
+    return;
+  } else {
+    unsigned int y = frame_dim[1];
+    unsigned int x = frame_dim[2];
+
+    if (H5Pset_chunk_cache(dapl, 521, 2 * dtype * y * x, 1.0) < 0) {
+      fprintf(stderr, "Error in H5Pset)chunk_cache\n");
+      return;
+    }
+  }
+
+  hid_t datatype;
+  switch (dtype) {
+    case 1: {
+      datatype = H5T_STD_U8LE;
+      break;
+    }
+    case 2: {
+      datatype = H5T_STD_U16LE;
+      break;
+    }
+    case 4: {
+      datatype = H5T_STD_U32LE;
+      break;
+    }
+    case 8: {
+      datatype = H5T_STD_U64LE;
+      break;
+    }
+    default: {
+      fprintf(stderr, "Error in datatype, please check input dtype\n");
+      return;
+    }
+  }
+
+  if ((*merlin_dataset_id = H5Dcreate2(file, merlin_dataset_name, datatype,
+                                       memspace, lcpl, dcpl, dapl)) ==
+      H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating merlin_dataset\n");
+    return;
+  }
+}

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -70,7 +70,6 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
   hid_t lcpl = *lcpl_id;
   hid_t dcpl;
   hid_t dapl;
-  // int fill_value = -1;
   unsigned int cd_values[7] = {0};
 
   if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
@@ -85,12 +84,6 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
       fprintf(stderr, "Error in H5Pset_fill_time\n");
       return;
     }
-    /*
-    if (H5Pset_fill_value(dcpl, H5T_NATIVE_INT, &fill_value) < 0) {
-      fprintf(stderr, "Error in H5Pset_fill_value\n");
-      return;
-    }
-   */
     cd_values[0] = 0;
     cd_values[1] = compression_level;
     cd_values[2] = shuffle;

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -31,6 +31,10 @@ void initialize_plist(hid_t *file_id,
 
 void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
 {
+  if (!filename) {
+    fprintf(stderr, "Empty or other error in filename, please check\n");
+  }
+
   if (!H5Iis_valid(fapl) || !H5Iis_valid(fcpl)) {
     fprintf(stderr, "fapl or fcpl is invalid in initialize_file\n");
     return;

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -2,7 +2,6 @@
 #include "blosc_filter.h"
 #include <blosc.h>
 #include <hdf5.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -25,12 +24,6 @@ void initialize_plist(char *filename,
       fprintf(stderr, "Error in H5Pset_alignment\n");
       return;
     }
-  }
-  if ((*file_id = H5Fcreate(filename, mode, *fcpl_id, *fapl_id)) ==
-      H5I_INVALID_HID) {
-    fprintf(stderr, "Error in creating file_id in create_file, please check if "
-                    "file already existed\n");
-    return;
   }
   if ((*lcpl_id = H5Pcreate(H5P_LINK_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating lcpl in initialize_dataset_plist\n");
@@ -80,18 +73,6 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     }
     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
       fprintf(stderr, "Error in H5Pset_fill_time\n");
-      return;
-    }
-    cd_values[0] = 0;
-    cd_values[1] = compression_level;
-    cd_values[2] = shuffle;
-    cd_values[3] = 0; // blocksize
-    cd_values[4] = 0; // unused
-    cd_values[5] = 0; // unused
-    cd_values[6] = compressor;
-    if (H5Pset_filter(dcpl, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) <
-        0) {
-      fprintf(stderr, "Error in H5Pset_filter\n");
       return;
     }
   }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -85,7 +85,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
 
     if (H5Pset_chunk_cache(dapl, PRIME_FOR_HASH,
                            NUM_CHUNKS_IN_CACHE * dtype * y * x, 1.0) < 0) {
-      fprintf(stderr, "Error in H5Pset)chunk_cache\n");
+      fprintf(stderr, "Error in H5Pset_chunk_cache\n");
       goto cleanup;
     }
   }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -4,8 +4,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-void initialize_plist(char *filename,
-                      hid_t *file_id,
+void initialize_plist(hid_t *file_id,
                       hid_t *fapl_id,
                       hid_t *fcpl_id,
                       hid_t *lcpl_id)

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -1,6 +1,5 @@
 #include "hdf5_init.h"
 #include "blosc_filter.h"
-
 #include <blosc.h>
 #include <hdf5.h>
 #include <math.h>
@@ -8,21 +7,6 @@
 #include <stdlib.h>
 #include <time.h>
 
-/*
-// functions for debugging
-void check_space_and_storage(hid_t dset) {
-        H5D_space_status_t space_status;
-        hsize_t storage_size;
-
-        status = H5Dget_space_status(dset, &space_status);
-        storage_size = H5Dget_storage_size(dset);
-        printf("Space for dataset has%sbeen allocated. \n", space_status ==
-H5D_SPACE_STATUS_ALLOCATED ? " " : " NOT "); printf("Storage size for dataset is
-: %ld bytes.\n", (long)storage_size);
-}
-*/
-
-// REAL functions
 void initialize_file_and_plist(char *filename,
                                hid_t *file_id,
                                hid_t *fapl_id,

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -76,8 +76,8 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     unsigned int y = frame_dim[1];
     unsigned int x = frame_dim[2];
 
-    if (H5Pset_chunk_cache(dapl, 521, NUM_CHUNKS_IN_CACHE * dtype * y * x,
-                           1.0) < 0) {
+    if (H5Pset_chunk_cache(dapl, PRIME_FOR_HASH,
+                           NUM_CHUNKS_IN_CACHE * dtype * y * x, 1.0) < 0) {
       fprintf(stderr, "Error in H5Pset)chunk_cache\n");
       return;
     }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -35,6 +35,7 @@ void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
 {
   if (filename == NULL) {
     fprintf(stderr, "Empty or other error in filename, please check\n");
+    return;
   }
 
   if (!H5Iis_valid(fapl) || !H5Iis_valid(fcpl)) {

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -64,21 +64,21 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
 
   if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating dcpl\n");
-    return;
+    goto cleanup;
   } else {
     if (H5Pset_chunk(dcpl, dim, frame_dim) < 0) {
       fprintf(stderr, "Error in H5Pset_chunk\n");
-      return;
+      goto cleanup;
     }
     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
       fprintf(stderr, "Error in H5Pset_fill_time\n");
-      return;
+      goto cleanup;
     }
   }
 
   if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating dapl_id\n");
-    return;
+    goto cleanup;
   } else {
     unsigned int y = frame_dim[1];
     unsigned int x = frame_dim[2];
@@ -86,7 +86,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     if (H5Pset_chunk_cache(dapl, PRIME_FOR_HASH,
                            NUM_CHUNKS_IN_CACHE * dtype * y * x, 1.0) < 0) {
       fprintf(stderr, "Error in H5Pset)chunk_cache\n");
-      return;
+      goto cleanup;
     }
   }
 
@@ -96,6 +96,11 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
                                        memspace, lcpl, dcpl, dapl)) ==
       H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating merlin_dataset\n");
-    return;
+    goto cleanup;
   }
+cleanup:
+  if (H5Iis_valid(dcpl))
+    H5Pclose(dcpl);
+  if (H5Iis_valid(dapl))
+    H5Pclose(dapl);
 }

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -42,6 +42,34 @@ void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
   }
 }
 
+hid_t bufsize_to_datatype(int dtype)
+{
+  hid_t datatype;
+  switch (dtype) {
+    case 1: {
+      datatype = H5T_STD_U8LE;
+      break;
+    }
+    case 2: {
+      datatype = H5T_STD_U16LE;
+      break;
+    }
+    case 4: {
+      datatype = H5T_STD_U32LE;
+      break;
+    }
+    case 8: {
+      datatype = H5T_STD_U64LE;
+      break;
+    }
+    default: {
+      fprintf(stderr, "Error in datatype, please check input dtype\n");
+      return;
+    }
+  }
+  return datatype;
+}
+
 void create_merlin_dataset(hid_t *merlin_dataset_id,
                            hid_t file,
                            char *merlin_dataset_name,
@@ -81,29 +109,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
     }
   }
 
-  hid_t datatype;
-  switch (dtype) {
-    case 1: {
-      datatype = H5T_STD_U8LE;
-      break;
-    }
-    case 2: {
-      datatype = H5T_STD_U16LE;
-      break;
-    }
-    case 4: {
-      datatype = H5T_STD_U32LE;
-      break;
-    }
-    case 8: {
-      datatype = H5T_STD_U64LE;
-      break;
-    }
-    default: {
-      fprintf(stderr, "Error in datatype, please check input dtype\n");
-      return;
-    }
-  }
+  hid_t datatype = bufsize_to_datatype(dtype);
 
   if ((*merlin_dataset_id = H5Dcreate2(file, merlin_dataset_name, datatype,
                                        memspace, lcpl, dcpl, dapl)) ==

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -7,14 +7,12 @@
 #include <stdlib.h>
 #include <time.h>
 
-void initialize_file_and_plist(char *filename,
-                               hid_t *file_id,
-                               hid_t *fapl_id,
-                               hid_t *fcpl_id)
+void initialize_plist(char *filename,
+                      hid_t *file_id,
+                      hid_t *fapl_id,
+                      hid_t *fcpl_id,
+                      hid_t *lcpl_id)
 {
-  unsigned mode = H5F_ACC_TRUNC;
-  char *version, *date;
-
   if ((*fcpl_id = H5Pcreate(H5P_FILE_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating fcpl in create_file\n");
     return;
@@ -34,34 +32,26 @@ void initialize_file_and_plist(char *filename,
                     "file already existed\n");
     return;
   }
-  if (register_blosc(&version, &date) < 0) {
-    fprintf(stderr, "Error in register_blosc\n");
-    return;
-  } else {
-    printf("Blosc version info: %s (%s)\n", version, date);
-    free(version);
-    free(date);
-  }
-}
-
-void initialize_lcpl(hid_t *lcpl_id)
-{
   if ((*lcpl_id = H5Pcreate(H5P_LINK_CREATE)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating lcpl in initialize_dataset_plist\n");
     return;
   }
-  /*
-  else {
-    if (H5Pset_create_intermediate_group(*lcpl_id, 1) < 0) {
-      fprintf(stderr, "Error in H5Pset_create_intermediate_group\n");
-      return;
-    }
-    if (H5Pset_char_encoding(*lcpl_id, H5T_CSET_UTF8) < 0) {
-      fprintf(stderr, "Error in H5Pset_char_encoding\n");
-      return;
-    }
+}
+
+void initialize_file(char *filename,
+                     hid_t *file_id,
+                     hid_t fapl,
+                     hid_t fcpl)
+{
+  if (!H5Iis_valid(fapl) || !H5Iis_valid(fcpl)) {
+    fprintf(stderr, "fapl or fcpl is invalid in initialize_file\n");
+    return;
   }
-  */
+
+  if ((*file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating file_id in intialize_file\n");
+    return;
+  }
 }
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -38,17 +38,15 @@ void initialize_plist(char *filename,
   }
 }
 
-void initialize_file(char *filename,
-                     hid_t *file_id,
-                     hid_t fapl,
-                     hid_t fcpl)
+void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl)
 {
   if (!H5Iis_valid(fapl) || !H5Iis_valid(fcpl)) {
     fprintf(stderr, "fapl or fcpl is invalid in initialize_file\n");
     return;
   }
 
-  if ((*file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) == H5I_INVALID_HID) {
+  if ((*file_id = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl, fapl)) ==
+      H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating file_id in intialize_file\n");
     return;
   }

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -13,8 +13,6 @@ void initialize_plist(char *path,
 
 void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl);
 
-hid_t bufsize_to_datatype(int dtype);
-
 void create_merlin_dataset(hid_t *merlin_dataset_id,
                            hid_t file,
                            char *merlin_dataset_name,

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -1,10 +1,10 @@
 // clang-format Language: C
-#ifndef HDF5_INIT_H
-#define HDF5_INIT_H
-
 #include <hdf5.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifndef HDF5_INIT_H
+#define HDF5_INIT_H
 
 void initialize_plist(char *path,
                       hid_t *fapl_id,

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -16,15 +16,12 @@ void initialize_plist(hid_t *file_id,
 void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl);
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,
-                           hid_t *file_id,
+                           hid_t file,
                            char *merlin_dataset_name,
                            int dtype,
                            hid_t memspace,
-                           hid_t *lcpl_id,
+                           hid_t lcpl,
                            size_t dim,
-                           hsize_t *frame_dim,
-                           unsigned int compression_level,
-                           unsigned int shuffle,
-                           unsigned int compressor);
+                           hsize_t *frame_dim);
 
 #endif

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -1,0 +1,32 @@
+// clang-format Language: C
+#ifndef HDF5_INIT_H
+#define HDF5_INIT_H
+
+#include <hdf5.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void check_space_and_storage(hid_t dset);
+
+void initialize_file_and_plist(char *filename,
+                               hid_t *file_id,
+                               hid_t *fapl_id,
+                               hid_t *fcpl_id);
+
+void initialize_lcpl(hid_t *lcpl_id);
+
+void create_merlin_dataset(hid_t *merlin_dataset_id,
+                           hid_t *file_id,
+                           char *merlin_dataset_name,
+                           int dtype,
+                           hid_t memspace,
+                           hid_t *lcpl_id,
+                           size_t dim,
+                           hsize_t *frame_dim,
+                           unsigned int compression_level,
+                           unsigned int shuffle,
+                           unsigned int compressor);
+
+#endif

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -3,10 +3,8 @@
 #define HDF5_INIT_H
 
 #include <hdf5.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
 void initialize_plist(hid_t *file_id,
                       hid_t *fapl_id,
@@ -14,6 +12,8 @@ void initialize_plist(hid_t *file_id,
                       hid_t *lcpl_id);
 
 void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl);
+
+hid_t bufsize_to_datatype(int dtype);
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,
                            hid_t file,

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-void check_space_and_storage(hid_t dset);
+// void check_space_and_storage(hid_t dset);
 
 void initialize_file_and_plist(char *filename,
                                hid_t *file_id,

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -1,6 +1,5 @@
 // clang-format Language: C
 #include <hdf5.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #ifndef HDF5_INIT_H

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -8,12 +8,12 @@
 #include <stdlib.h>
 #include <time.h>
 
-void initialize_file_and_plist(char *filename,
-                               hid_t *file_id,
-                               hid_t *fapl_id,
-                               hid_t *fcpl_id);
+void initialize_plist(hid_t *file_id,
+                      hid_t *fapl_id,
+                      hid_t *fcpl_id,
+                      hid_t *lcpl_id);
 
-void initialize_lcpl(hid_t *lcpl_id);
+void initialize_file(char *filename, hid_t *file_id, hid_t fapl, hid_t fcpl);
 
 void create_merlin_dataset(hid_t *merlin_dataset_id,
                            hid_t *file_id,

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void initialize_plist(hid_t *file_id,
+void initialize_plist(char *path,
                       hid_t *fapl_id,
                       hid_t *fcpl_id,
                       hid_t *lcpl_id);

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -8,8 +8,6 @@
 #include <stdlib.h>
 #include <time.h>
 
-// void check_space_and_storage(hid_t dset);
-
 void initialize_file_and_plist(char *filename,
                                hid_t *file_id,
                                hid_t *fapl_id,

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -155,7 +155,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   size_t num_datasets    = sizeof(fields) / sizeof(fields[0]);
   size_t num_meta_handle = sizeof(meta_handle) / sizeof(hid_t);
 
-  if (num_meta_handle < num_data) {
+  if (num_meta_handle < num_datasets) {
     fprintf(stderr, "meta_handle not enough space, please check declaration in "
                     "main and hdf5_init.c");
     goto label_close_threshold;

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -2,7 +2,6 @@
 #include "macros.h"
 
 #include <hdf5.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -158,7 +158,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   if (num_meta_handle < num_data) {
     fprintf(stderr, "meta_handle not enough space, please check declaration in "
                     "main and hdf5_init.c");
-    goto label_close_ext_timestmp;
+    goto label_close_threshold;
   }
 
   for (size_t i = 0; i < num_datasets; i++) {

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -7,17 +7,12 @@
 #include <stdlib.h>
 #include <time.h>
 
-void create_meta_mq1_fields_dataset(hid_t *file_id,
-                                    hid_t *lcpl_id,
-                                    hid_t *meta_handle)
+void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
 {
   if (meta_handle == NULL) {
     fprintf(stderr, "meta_handle is NULL in create_meta_fields_dataset\n");
     return;
   }
-
-  hid_t file = *file_id;
-  hid_t lcpl = *lcpl_id;
 
   char meta_group_path[64] = "metadata";
   hid_t meta_group =
@@ -152,8 +147,8 @@ void create_meta_mq1_fields_dataset(hid_t *file_id,
 }
 
 void create_dac_dataset(unsigned int num_chips,
-                        hid_t *file_id,
-                        hid_t *lcpl_id,
+                        hid_t file,
+                        hid_t lcpl,
                         hid_t *dac_handle)
 {
   if (dac_handle == NULL) {
@@ -161,13 +156,6 @@ void create_dac_dataset(unsigned int num_chips,
     return;
   }
 
-  hid_t file = *file_id;
-  hid_t lcpl;
-  if (lcpl_id == NULL) {
-    lcpl = H5P_DEFAULT;
-  } else {
-    lcpl = *lcpl_id;
-  }
   char chip_group_path[256];
   char dataset_path[512];
   hid_t chip_group;

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -152,12 +152,11 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     {"bit_depth", H5T_NATIVE_UINT},
   };
 
-  size_t num_datasets    = sizeof(fields) / sizeof(fields[0]);
-  size_t num_meta_handle = sizeof(meta_handle) / sizeof(hid_t);
+  size_t num_datasets = sizeof(fields) / sizeof(fields[0]);
 
-  if (num_meta_handle < num_datasets) {
-    fprintf(stderr, "meta_handle not enough space, please check declaration in "
-                    "main and hdf5_init.c");
+  if (num_datasets != MQ1_FIELDS_NUM_FIELD) {
+    fprintf(stderr,
+            "Number of dataset not match in create_meta_mq1_fields_dataset\n");
     goto label_close_threshold;
   }
 

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -152,12 +152,17 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     {"bit_depth", H5T_NATIVE_UINT},
   };
 
-  size_t num_datasets = sizeof(fields) / sizeof(fields[0]);
+  size_t num_datasets    = sizeof(fields) / sizeof(fields[0]);
+  size_t num_meta_handle = sizeof(meta_handle) / sizeof(hid_t);
+
+  if (num_meta_handle < num_data) {
+    fprintf(stderr, "meta_handle not enough space, please check declaration in "
+                    "main and hdf5_init.c");
+    goto label_close_ext_timestmp;
+  }
 
   for (size_t i = 0; i < num_datasets; i++) {
     char dataset_path[256];
-    // snprintf(dataset_path, sizeof(dataset_path), "metadata/%s",
-    // fields[i].name);
 
     snprintf(dataset_path, sizeof(dataset_path), "%s", fields[i].name);
 
@@ -187,7 +192,6 @@ label_close_sensor:
   H5Tclose(sensor_layout_type);
 label_close_pixel:
   H5Tclose(pixel_depth_type);
-
 label_close4:
   H5Pclose(dapl);
 label_close3:

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -270,6 +270,9 @@ void create_dac_dataset(unsigned int num_chips,
         dac_handle[j] = H5I_INVALID_HID;
         continue;
       }
+      // else {
+      //   printf("Created dataset: %s\n", dataset_path);
+      // }
       dac_handle[j] = dataset;
     }
 
@@ -284,10 +287,12 @@ void create_dac_dataset(unsigned int num_chips,
 
 void close_dataset_handle(hid_t *handle, size_t count)
 {
-  if (!handle)
+  if (!handle) {
+    printf("No handle\n");
     return;
+  }
   for (size_t i = 0; i < count; i++) {
-    if (handle[i] >= 0) {
+    if (H5Iis_valid(handle[i])) {
       H5Dclose(handle[i]);
     }
   }

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -216,6 +216,13 @@ void create_dac_dataset(unsigned int num_chips,
                         hid_t lcpl,
                         hid_t *dac_handle)
 {
+  hid_t dcpl       = H5I_INVALID_HID;
+  hid_t dcpl       = H5I_INVALID_HID;
+  hid_t chip_group = H5I_INVALID_HID;
+  hid_t dataspace  = H5I_INVALID_HID;
+  hid_t dataset    = H5I_INVALID_HID;
+  hid_t str_type   = H5I_INVALID_HID;
+
   if (dac_handle == NULL) {
     fprintf(stderr, "dac_handle is NULL in create_dac_meta_dataset\n");
     return;
@@ -223,17 +230,14 @@ void create_dac_dataset(unsigned int num_chips,
 
   char chip_group_path[256];
   char dataset_path[512];
-  hid_t chip_group;
   hsize_t dim[1]       = {0};
   hsize_t max_dim[1]   = {H5S_UNLIMITED};
   hsize_t chunk_dim[1] = {1};
-  hid_t dataspace;
-  hid_t dataset;
 
-  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  dcpl = H5Pcreate(H5P_DATASET_CREATE);
   if (dcpl < 0) {
     fprintf(stderr, "Error creating dcpl in create_dac_dataset\n");
-    return;
+    goto cleanup;
   } else {
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
       fprintf(stderr, "Error setting chunking in create_dac_dataset\n");
@@ -241,16 +245,17 @@ void create_dac_dataset(unsigned int num_chips,
     }
   }
 
-  hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+  dapl = H5Pcreate(H5P_DATASET_ACCESS);
   if (dapl < 0) {
     fprintf(stderr, "Error creating dapl in create_dac_dataset\n");
-    H5Pclose(dcpl);
-    return;
-  } else {
-    // modify dapl if needed
+    goto cleanup;
   }
 
-  hid_t str_type = H5Tcopy(H5T_C_S1);
+  str_type = H5Tcopy(H5T_C_S1);
+  if (str_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for str_type\n");
+    goto cleanup;
+  }
   if (H5Tset_size(str_type, 4) < 0) {
     fprintf(stderr, "Error setting string type size in create_dac_dataset\n");
     goto cleanup;
@@ -298,8 +303,6 @@ void create_dac_dataset(unsigned int num_chips,
     handle_pos = num_datasets * (size_t) i;
 
     for (size_t j = handle_pos; j < (handle_pos + num_datasets); j++) {
-      // snprintf(dataset_path, sizeof(dataset_path), "%s/%s", chip_group_path,
-      // datasets[j-handle_pos].name);
 
       snprintf(dataset_path, sizeof(dataset_path), "%s",
                datasets[j - handle_pos].name);
@@ -312,12 +315,8 @@ void create_dac_dataset(unsigned int num_chips,
         dac_handle[j] = H5I_INVALID_HID;
         continue;
       }
-      // else {
-      //   printf("Created dataset: %s\n", dataset_path);
-      // }
       dac_handle[j] = dataset;
     }
-
     H5Sclose(dataspace);
     H5Gclose(chip_group);
   }

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -183,7 +183,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
 
 cleanup:
   // H5Tclose(header_id_type);
-  if (H5Iis_valid(pixel_depth_type))
+  if (H5Iis_valid(threshold_type))
     H5Tclose(threshold_type);
   if (H5Iis_valid(extended_timestamp_type))
     H5Tclose(extended_timestamp_type);

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -9,14 +9,25 @@
 
 void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
 {
+  hid_t pixel_depth_type         = H5I_INVALID_HID;
+  hid_t sensor_layout_type       = H5I_INVALID_HID;
+  hid_t chip_select_type         = H5I_INVALID_HID;
+  hid_t timestamp_type           = H5I_INVALID_HID;
+  hid_t header_extension_id_type = H5I_INVALID_HID;
+  hid_t extended_timestamp_type  = H5I_INVALID_HID;
+  hsize_t threshold_dims[1]      = {MQ1_FLOAT_LEN_THRESHOLD};
+  hid_t threshold_type           = H5I_INVALID_HID;
+  hid_t dataspace                = H5I_INVALID_HID;
+  hid_t dcpl                     = H5I_INVALID_HID;
+  hid_t dapl                     = H5I_INVALID_HID;
+  hid_meta_group                 = H5I_INVALID_HID;
   if (meta_handle == NULL) {
     fprintf(stderr, "meta_handle is NULL in create_meta_fields_dataset\n");
     return;
   }
 
   char meta_group_path[64] = "metadata";
-  hid_t meta_group =
-    H5Gcreate(file, meta_group_path, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+  meta_group = H5Gcreate(file, meta_group_path, lcpl, H5P_DEFAULT, H5P_DEFAULT);
   if (meta_group < 0) {
     fprintf(stderr, "Error creating group in create_meta_mq1_fields_dataset\n");
     goto cleanup;
@@ -26,14 +37,14 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   hsize_t max_dim[1]   = {H5S_UNLIMITED};
   hsize_t chunk_dim[1] = {1};
 
-  hid_t dataspace = H5Screate_simple(1, dim, max_dim);
+  dataspace = H5Screate_simple(1, dim, max_dim);
   if (dataspace < 0) {
     fprintf(stderr,
             "Error creating dataspace in create_meta_mq1_fields_dataset\n");
     goto cleanup;
   }
 
-  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  dcpl = H5Pcreate(H5P_DATASET_CREATE);
   if (dcpl < 0) {
     fprintf(stderr, "Error creating dcpl in create_meta_mq1_fields_dataset\n");
     goto cleanup;
@@ -45,7 +56,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     }
   }
 
-  hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+  dapl = H5Pcreate(H5P_DATASET_ACCESS);
   if (dapl < 0) {
     fprintf(stderr,
             "Error in creating dapl in create_meta_mq1_fields_dataset\n");
@@ -56,8 +67,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   // hid_t header_id_type = H5Tcopy(H5T_C_S1);
   // H5Tset_size(header_id_type, MQ1_CHAR_LEN_HEADER_ID);
 
-  hid_t pixel_depth_type = H5I_INVALID_HID;
-  pixel_depth_type       = H5Tcopy(H5T_C_S1);
+  pixel_depth_type = H5Tcopy(H5T_C_S1);
   if (pixel_depth_type < 0) {
     fprintf(stderr, "H5Tcopy failed for pixel_depth_type\n");
     goto cleanup;
@@ -67,8 +77,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hid_t sensor_layout_type = H5I_INVALID_HID;
-  sensor_layout_type       = H5Tcopy(H5T_C_S1);
+  sensor_layout_type = H5Tcopy(H5T_C_S1);
   if (sensor_layout_type < 0) {
     fprintf(stderr, "H5Tcopy failed for sensor_layout_type\n");
     goto cleanup;
@@ -78,8 +87,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hid_t chip_select_type = H5I_INVALID_HID;
-  chip_select_type       = H5Tcopy(H5T_C_S1);
+  chip_select_type = H5Tcopy(H5T_C_S1);
   if (chip_select_type < 0) {
     fprintf(stderr, "H5Tcopy failed for chip_select_type\n");
     goto cleanup;
@@ -89,8 +97,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hid_t timestamp_type = H5I_INVALID_HID;
-  timestamp_type       = H5Tcopy(H5T_C_S1);
+  timestamp_type = H5Tcopy(H5T_C_S1);
   if (timestamp_type < 0) {
     fprintf(stderr, "H5Tcopy failed for timestamp_type\n");
     goto cleanup;
@@ -100,8 +107,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hid_t header_extension_id_type = H5I_INVALID_HID;
-  header_extension_id_type       = H5Tcopy(H5T_C_S1);
+  header_extension_id_type = H5Tcopy(H5T_C_S1);
   if (header_extension_id_type < 0) {
     fprintf(stderr, "H5Tcopy failed for header_extension_id_type\n");
     goto cleanup;
@@ -112,8 +118,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hid_t extended_timestamp_type = H5I_INVALID_HID;
-  extended_timestamp_type       = H5Tcopy(H5T_C_S1);
+  extended_timestamp_type = H5Tcopy(H5T_C_S1);
   if (extended_timestamp_type < 0) {
     fprintf(stderr, "H5Tcopy failed for extended_timestamp_type\n");
     goto cleanup;
@@ -124,8 +129,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     goto cleanup;
   }
 
-  hsize_t threshold_dims[1] = {MQ1_FLOAT_LEN_THRESHOLD};
-  hid_t threshold_type = H5Tarray_create(H5T_NATIVE_FLOAT, 1, threshold_dims);
+  threshold_type = H5Tarray_create(H5T_NATIVE_FLOAT, 1, threshold_dims);
   if (threshold_type < 0) {
     fprintf(stderr, "H5Tarray_create failed for thresholds\n");
     goto cleanup;

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -20,7 +20,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   hid_t dataspace                = H5I_INVALID_HID;
   hid_t dcpl                     = H5I_INVALID_HID;
   hid_t dapl                     = H5I_INVALID_HID;
-  hid_meta_group                 = H5I_INVALID_HID;
+  hid_t meta_group               = H5I_INVALID_HID;
   if (meta_handle == NULL) {
     fprintf(stderr, "meta_handle is NULL in create_meta_fields_dataset\n");
     return;

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -216,7 +216,7 @@ void create_dac_dataset(unsigned int num_chips,
                         hid_t *dac_handle)
 {
   hid_t dcpl       = H5I_INVALID_HID;
-  hid_t dcpl       = H5I_INVALID_HID;
+  hid_t dapl       = H5I_INVALID_HID;
   hid_t chip_group = H5I_INVALID_HID;
   hid_t dataspace  = H5I_INVALID_HID;
   hid_t dataset    = H5I_INVALID_HID;

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -19,7 +19,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     H5Gcreate(file, meta_group_path, lcpl, H5P_DEFAULT, H5P_DEFAULT);
   if (meta_group < 0) {
     fprintf(stderr, "Error creating group in create_meta_mq1_fields_dataset\n");
-    return;
+    goto cleanup;
   }
 
   hsize_t dim[1]       = {0};
@@ -30,19 +30,18 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   if (dataspace < 0) {
     fprintf(stderr,
             "Error creating dataspace in create_meta_mq1_fields_dataset\n");
-    goto label_close1;
-    return;
+    goto cleanup;
   }
 
   hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
   if (dcpl < 0) {
     fprintf(stderr, "Error creating dcpl in create_meta_mq1_fields_dataset\n");
-    goto label_close2;
+    goto cleanup;
   } else {
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
       fprintf(stderr,
               "Error setting chunking in create_meta_mq1_fields_dataset\n");
-      goto label_close3;
+      goto cleanup;
     }
   }
 
@@ -50,80 +49,86 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   if (dapl < 0) {
     fprintf(stderr,
             "Error in creating dapl in create_meta_mq1_fields_dataset\n");
-    goto label_close3;
+    goto cleanup;
   } else {
   }
 
   // hid_t header_id_type = H5Tcopy(H5T_C_S1);
   // H5Tset_size(header_id_type, MQ1_CHAR_LEN_HEADER_ID);
 
-  hid_t pixel_depth_type = H5Tcopy(H5T_C_S1);
+  hid_t pixel_depth_type = H5I_INVALID_HID;
+  pixel_depth_type       = H5Tcopy(H5T_C_S1);
   if (pixel_depth_type < 0) {
     fprintf(stderr, "H5Tcopy failed for pixel_depth_type\n");
-    goto label_close4;
+    goto cleanup;
   }
   if (H5Tset_size(pixel_depth_type, MQ1_CHAR_LEN_PIXEL_DEPTH) < 0) {
     fprintf(stderr, "H5Tsetsize failed for pixel_depth_type\n");
-    goto label_close_pixel;
+    goto cleanup;
   }
 
-  hid_t sensor_layout_type = H5Tcopy(H5T_C_S1);
+  hid_t sensor_layout_type = H5I_INVALID_HID;
+  sensor_layout_type       = H5Tcopy(H5T_C_S1);
   if (sensor_layout_type < 0) {
     fprintf(stderr, "H5Tcopy failed for sensor_layout_type\n");
-    goto label_close_pixel;
+    goto cleanup;
   }
   if (H5Tset_size(sensor_layout_type, MQ1_CHAR_LEN_SENSOR_LAYOUT) < 0) {
     fprintf(stderr, "H5Tset_size failed for sensor_layout_type\n");
-    goto label_close_sensor;
+    goto cleanup;
   }
 
-  hid_t chip_select_type = H5Tcopy(H5T_C_S1);
+  hid_t chip_select_type = H5I_INVALID_HID;
+  chip_select_type       = H5Tcopy(H5T_C_S1);
   if (chip_select_type < 0) {
     fprintf(stderr, "H5Tcopy failed for chip_select_type\n");
-    goto label_close_sensor;
+    goto cleanup;
   }
   if (H5Tset_size(chip_select_type, MQ1_CHAR_LEN_CHIP_SELECT) < 0) {
     fprintf(stderr, "H5Tset_size failed for chip_select_type\n");
-    goto label_close_chip;
+    goto cleanup;
   }
 
-  hid_t timestamp_type = H5Tcopy(H5T_C_S1);
+  hid_t timestamp_type = H5I_INVALID_HID;
+  timestamp_type       = H5Tcopy(H5T_C_S1);
   if (timestamp_type < 0) {
     fprintf(stderr, "H5Tcopy failed for timestamp_type\n");
-    goto label_close_chip;
+    goto cleanup;
   }
   if (H5Tset_size(timestamp_type, MQ1_CHAR_LEN_TIMESTAMP) < 0) {
     fprintf(stderr, "H5Tset_size failed for timestamp_type\n");
-    goto label_close_timestamp;
+    goto cleanup;
   }
 
-  hid_t header_extension_id_type = H5Tcopy(H5T_C_S1);
+  hid_t header_extension_id_type = H5I_INVALID_HID;
+  header_extension_id_type       = H5Tcopy(H5T_C_S1);
   if (header_extension_id_type < 0) {
     fprintf(stderr, "H5Tcopy failed for header_extension_id_type\n");
-    goto label_close_timestamp;
+    goto cleanup;
   }
   if (H5Tset_size(header_extension_id_type, MQ1_CHAR_LEN_HEADER_EXTENSION_ID) <
       0) {
     fprintf(stderr, "H5Tset_size failed for header_extension_id_type\n");
-    goto label_close_header_ext;
+    goto cleanup;
   }
 
-  hid_t extended_timestamp_type = H5Tcopy(H5T_C_S1);
+  hid_t extended_timestamp_type = H5I_INVALID_HID;
+  extended_timestamp_type       = H5Tcopy(H5T_C_S1);
   if (extended_timestamp_type < 0) {
     fprintf(stderr, "H5Tcopy failed for extended_timestamp_type\n");
-    goto label_close_header_ext;
+    goto cleanup;
   }
   if (H5Tset_size(extended_timestamp_type, MQ1_CHAR_LEN_EXTENDED_TIMESTAMP) <
       0) {
     fprintf(stderr, "H5Tset_size failed for extended_timestamp_type\n");
-    goto label_close_ext_timestamp;
+    goto cleanup;
   }
 
   hsize_t threshold_dims[1] = {MQ1_FLOAT_LEN_THRESHOLD};
   hid_t threshold_type = H5Tarray_create(H5T_NATIVE_FLOAT, 1, threshold_dims);
   if (threshold_type < 0) {
     fprintf(stderr, "H5Tarray_create failed for thresholds\n");
-    goto label_close_ext_timestamp;
+    goto cleanup;
   }
 
   struct {
@@ -154,10 +159,10 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
 
   size_t num_datasets = sizeof(fields) / sizeof(fields[0]);
 
-  if (num_datasets != MQ1_FIELDS_NUM_FIELD) {
+  if (num_datasets != MQ1_FIELDS_NUM_FIELDS) {
     fprintf(stderr,
             "Number of dataset not match in create_meta_mq1_fields_dataset\n");
-    goto label_close_threshold;
+    goto cleanup;
   }
 
   for (size_t i = 0; i < num_datasets; i++) {
@@ -176,29 +181,30 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
     meta_handle[i] = dataset;
   }
 
+cleanup:
   // H5Tclose(header_id_type);
-label_close_threshold:
-  H5Tclose(threshold_type);
-label_close_ext_timestamp:
-  H5Tclose(extended_timestamp_type);
-label_close_header_ext:
-  H5Tclose(header_extension_id_type);
-label_close_timestamp:
-  H5Tclose(timestamp_type);
-label_close_chip:
-  H5Tclose(chip_select_type);
-label_close_sensor:
-  H5Tclose(sensor_layout_type);
-label_close_pixel:
-  H5Tclose(pixel_depth_type);
-label_close4:
-  H5Pclose(dapl);
-label_close3:
-  H5Pclose(dcpl);
-label_close2:
-  H5Sclose(dataspace);
-label_close1:
-  H5Gclose(meta_group);
+  if (H5Iis_valid(pixel_depth_type))
+    H5Tclose(threshold_type);
+  if (H5Iis_valid(extended_timestamp_type))
+    H5Tclose(extended_timestamp_type);
+  if (H5Iis_valid(header_extension_id_type))
+    H5Tclose(header_extension_id_type);
+  if (H5Iis_valid(timestamp_type))
+    H5Tclose(timestamp_type);
+  if (H5Iis_valid(chip_select_type))
+    H5Tclose(chip_select_type);
+  if (H5Iis_valid(sensor_layout_type))
+    H5Tclose(sensor_layout_type);
+  if (H5Iis_valid(pixel_depth_type))
+    H5Tclose(pixel_depth_type);
+  if (H5Iis_valid(dapl))
+    H5Pclose(dapl);
+  if (H5Iis_valid(dcpl))
+    H5Pclose(dcpl);
+  if (H5Iis_valid(dataspace))
+    H5Sclose(dataspace);
+  if (H5Iis_valid(meta_group))
+    H5Gclose(meta_group);
 }
 
 void create_dac_dataset(unsigned int num_chips,

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -30,23 +30,19 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   if (dataspace < 0) {
     fprintf(stderr,
             "Error creating dataspace in create_meta_mq1_fields_dataset\n");
+    goto label_close1;
     return;
   }
 
   hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
   if (dcpl < 0) {
     fprintf(stderr, "Error creating dcpl in create_meta_mq1_fields_dataset\n");
-    H5Sclose(dataspace);
-    H5Gclose(meta_group);
-    return;
+    goto label_close2;
   } else {
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
       fprintf(stderr,
               "Error setting chunking in create_meta_mq1_fields_dataset\n");
-      H5Pclose(dcpl);
-      H5Sclose(dataspace);
-      H5Gclose(meta_group);
-      return;
+      goto label_close3;
     }
   }
 
@@ -54,10 +50,7 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   if (dapl < 0) {
     fprintf(stderr,
             "Error in creating dapl in create_meta_mq1_fields_dataset\n");
-    H5Pclose(dcpl);
-    H5Sclose(dataspace);
-    H5Gclose(meta_group);
-    return;
+    goto label_close3;
   } else {
   }
 
@@ -65,25 +58,73 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   // H5Tset_size(header_id_type, MQ1_CHAR_LEN_HEADER_ID);
 
   hid_t pixel_depth_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(pixel_depth_type, MQ1_CHAR_LEN_PIXEL_DEPTH);
+  if (pixel_depth_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for pixel_depth_type\n");
+    goto label_close4;
+  }
+  if (H5Tset_size(pixel_depth_type, MQ1_CHAR_LEN_PIXEL_DEPTH) < 0) {
+    fprintf(stderr, "H5Tsetsize failed for pixel_depth_type\n");
+    goto label_close_pixel;
+  }
 
   hid_t sensor_layout_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(sensor_layout_type, MQ1_CHAR_LEN_SENSOR_LAYOUT);
+  if (sensor_layout_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for sensor_layout_type\n");
+    goto label_close_pixel;
+  }
+  if (H5Tset_size(sensor_layout_type, MQ1_CHAR_LEN_SENSOR_LAYOUT) < 0) {
+    fprintf(stderr, "H5Tset_size failed for sensor_layout_type\n");
+    goto label_close_sensor;
+  }
 
   hid_t chip_select_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(chip_select_type, MQ1_CHAR_LEN_CHIP_SELECT);
+  if (chip_select_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for chip_select_type\n");
+    goto label_close_sensor;
+  }
+  if (H5Tset_size(chip_select_type, MQ1_CHAR_LEN_CHIP_SELECT) < 0) {
+    fprintf(stderr, "H5Tset_size failed for chip_select_type\n");
+    goto label_close_chip;
+  }
 
   hid_t timestamp_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(timestamp_type, MQ1_CHAR_LEN_TIMESTAMP);
+  if (timestamp_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for timestamp_type\n");
+    goto label_close_chip;
+  }
+  if (H5Tset_size(timestamp_type, MQ1_CHAR_LEN_TIMESTAMP) < 0) {
+    fprintf(stderr, "H5Tset_size failed for timestamp_type\n");
+    goto label_close_timestamp;
+  }
 
   hid_t header_extension_id_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(header_extension_id_type, MQ1_CHAR_LEN_HEADER_EXTENSION_ID);
+  if (header_extension_id_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for header_extension_id_type\n");
+    goto label_close_timestamp;
+  }
+  if (H5Tset_size(header_extension_id_type, MQ1_CHAR_LEN_HEADER_EXTENSION_ID) <
+      0) {
+    fprintf(stderr, "H5Tset_size failed for header_extension_id_type\n");
+    goto label_close_header_ext;
+  }
 
   hid_t extended_timestamp_type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(extended_timestamp_type, MQ1_CHAR_LEN_EXTENDED_TIMESTAMP);
+  if (extended_timestamp_type < 0) {
+    fprintf(stderr, "H5Tcopy failed for extended_timestamp_type\n");
+    goto label_close_header_ext;
+  }
+  if (H5Tset_size(extended_timestamp_type, MQ1_CHAR_LEN_EXTENDED_TIMESTAMP) <
+      0) {
+    fprintf(stderr, "H5Tset_size failed for extended_timestamp_type\n");
+    goto label_close_ext_timestamp;
+  }
 
   hsize_t threshold_dims[1] = {MQ1_FLOAT_LEN_THRESHOLD};
   hid_t threshold_type = H5Tarray_create(H5T_NATIVE_FLOAT, 1, threshold_dims);
+  if (threshold_type < 0) {
+    fprintf(stderr, "H5Tarray_create failed for thresholds\n");
+    goto label_close_ext_timestamp;
+  }
 
   struct {
     const char *name;
@@ -132,17 +173,28 @@ void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle)
   }
 
   // H5Tclose(header_id_type);
-  H5Tclose(pixel_depth_type);
-  H5Tclose(sensor_layout_type);
-  H5Tclose(chip_select_type);
-  H5Tclose(timestamp_type);
-  H5Tclose(header_extension_id_type);
-  H5Tclose(extended_timestamp_type);
+label_close_threshold:
   H5Tclose(threshold_type);
+label_close_ext_timestamp:
+  H5Tclose(extended_timestamp_type);
+label_close_header_ext:
+  H5Tclose(header_extension_id_type);
+label_close_timestamp:
+  H5Tclose(timestamp_type);
+label_close_chip:
+  H5Tclose(chip_select_type);
+label_close_sensor:
+  H5Tclose(sensor_layout_type);
+label_close_pixel:
+  H5Tclose(pixel_depth_type);
 
-  H5Pclose(dcpl);
+label_close4:
   H5Pclose(dapl);
+label_close3:
+  H5Pclose(dcpl);
+label_close2:
   H5Sclose(dataspace);
+label_close1:
   H5Gclose(meta_group);
 }
 

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -1,0 +1,294 @@
+#include "hdf5_init_meta.h"
+#include "macros.h"
+
+#include <hdf5.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void create_meta_mq1_fields_dataset(hid_t *file_id,
+                                    hid_t *lcpl_id,
+                                    hid_t *meta_handle)
+{
+  if (meta_handle == NULL) {
+    fprintf(stderr, "meta_handle is NULL in create_meta_fields_dataset\n");
+    return;
+  }
+
+  hid_t file = *file_id;
+  hid_t lcpl = *lcpl_id;
+
+  char meta_group_path[64] = "metadata";
+  hid_t meta_group =
+    H5Gcreate(file, meta_group_path, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+  if (meta_group < 0) {
+    fprintf(stderr, "Error creating group in create_meta_mq1_fields_dataset\n");
+    return;
+  }
+
+  hsize_t dim[1]       = {0};
+  hsize_t max_dim[1]   = {H5S_UNLIMITED};
+  hsize_t chunk_dim[1] = {1};
+
+  hid_t dataspace = H5Screate_simple(1, dim, max_dim);
+  if (dataspace < 0) {
+    fprintf(stderr,
+            "Error creating dataspace in create_meta_mq1_fields_dataset\n");
+    return;
+  }
+
+  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  if (dcpl < 0) {
+    fprintf(stderr, "Error creating dcpl in create_meta_mq1_fields_dataset\n");
+    H5Sclose(dataspace);
+    H5Gclose(meta_group);
+    return;
+  } else {
+    if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
+      fprintf(stderr,
+              "Error setting chunking in create_meta_mq1_fields_dataset\n");
+      H5Pclose(dcpl);
+      H5Sclose(dataspace);
+      H5Gclose(meta_group);
+      return;
+    }
+  }
+
+  hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+  if (dapl < 0) {
+    fprintf(stderr,
+            "Error in creating dapl in create_meta_mq1_fields_dataset\n");
+    H5Pclose(dcpl);
+    H5Sclose(dataspace);
+    H5Gclose(meta_group);
+    return;
+  } else {
+  }
+
+  // hid_t header_id_type = H5Tcopy(H5T_C_S1);
+  // H5Tset_size(header_id_type, MQ1_CHAR_LEN_HEADER_ID);
+
+  hid_t pixel_depth_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(pixel_depth_type, MQ1_CHAR_LEN_PIXEL_DEPTH);
+
+  hid_t sensor_layout_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(sensor_layout_type, MQ1_CHAR_LEN_SENSOR_LAYOUT);
+
+  hid_t chip_select_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(chip_select_type, MQ1_CHAR_LEN_CHIP_SELECT);
+
+  hid_t timestamp_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(timestamp_type, MQ1_CHAR_LEN_TIMESTAMP);
+
+  hid_t header_extension_id_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(header_extension_id_type, MQ1_CHAR_LEN_HEADER_EXTENSION_ID);
+
+  hid_t extended_timestamp_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(extended_timestamp_type, MQ1_CHAR_LEN_EXTENDED_TIMESTAMP);
+
+  hsize_t threshold_dims[1] = {MQ1_FLOAT_LEN_THRESHOLD};
+  hid_t threshold_type = H5Tarray_create(H5T_NATIVE_FLOAT, 1, threshold_dims);
+
+  struct {
+    const char *name;
+    hid_t type;
+  } fields[] = {
+    //{"header_id", header_id_type},
+    {"max_length", H5T_NATIVE_UINT},
+    {"sequence_number", H5T_NATIVE_UINT},
+    {"header_bytes", H5T_NATIVE_UINT},
+    {"num_chips", H5T_NATIVE_UINT},
+    {"det_x", H5T_NATIVE_UINT},
+    {"det_y", H5T_NATIVE_UINT},
+    {"pixel_depth", pixel_depth_type},
+    {"sensor_layout", sensor_layout_type},
+    {"chip_select", chip_select_type},
+    {"timestamp", timestamp_type},
+    {"exposure_time_s", H5T_NATIVE_DOUBLE},
+    {"counter", H5T_NATIVE_UINT},
+    {"colour_mode", H5T_NATIVE_UINT},
+    {"gain_mode", H5T_NATIVE_UINT},
+    {"threshold", threshold_type},
+    {"header_extension_id", header_extension_id_type},
+    {"extended_timestamp", extended_timestamp_type},
+    {"exposure_time_ns", H5T_NATIVE_UINT},
+    {"bit_depth", H5T_NATIVE_UINT},
+  };
+
+  size_t num_datasets = sizeof(fields) / sizeof(fields[0]);
+
+  for (size_t i = 0; i < num_datasets; i++) {
+    char dataset_path[256];
+    // snprintf(dataset_path, sizeof(dataset_path), "metadata/%s",
+    // fields[i].name);
+
+    snprintf(dataset_path, sizeof(dataset_path), "%s", fields[i].name);
+
+    hid_t dataset = H5Dcreate2(meta_group, dataset_path, fields[i].type,
+                               dataspace, lcpl, dcpl, dapl);
+    if (dataset < 0) {
+      fprintf(stderr, "Error creating dataset : %s\n", dataset_path);
+      meta_handle[i] = -1;
+      continue;
+    }
+
+    meta_handle[i] = dataset;
+  }
+
+  // H5Tclose(header_id_type);
+  H5Tclose(pixel_depth_type);
+  H5Tclose(sensor_layout_type);
+  H5Tclose(chip_select_type);
+  H5Tclose(timestamp_type);
+  H5Tclose(header_extension_id_type);
+  H5Tclose(extended_timestamp_type);
+  H5Tclose(threshold_type);
+
+  H5Pclose(dcpl);
+  H5Pclose(dapl);
+  H5Sclose(dataspace);
+  H5Gclose(meta_group);
+}
+
+void create_dac_dataset(unsigned int num_chips,
+                        hid_t *file_id,
+                        hid_t *lcpl_id,
+                        hid_t *dac_handle)
+{
+  if (dac_handle == NULL) {
+    fprintf(stderr, "dac_handle is NULL in create_dac_meta_dataset\n");
+    return;
+  }
+
+  hid_t file = *file_id;
+  hid_t lcpl;
+  if (lcpl_id == NULL) {
+    lcpl = H5P_DEFAULT;
+  } else {
+    lcpl = *lcpl_id;
+  }
+  char chip_group_path[256];
+  char dataset_path[512];
+  hid_t chip_group;
+  hsize_t dim[1]       = {0};
+  hsize_t max_dim[1]   = {H5S_UNLIMITED};
+  hsize_t chunk_dim[1] = {1};
+  hid_t dataspace;
+  hid_t dataset;
+
+  hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+  if (dcpl < 0) {
+    fprintf(stderr, "Error creating dcpl in create_dac_dataset\n");
+    return;
+  } else {
+    if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
+      fprintf(stderr, "Error setting chunking in create_dac_dataset\n");
+      H5Pclose(dcpl);
+      return;
+    }
+  }
+
+  hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+  if (dapl < 0) {
+    fprintf(stderr, "Error creating dapl in create_dac_dataset\n");
+    H5Pclose(dcpl);
+    return;
+  } else {
+    // modify dapl if needed
+  }
+
+  hid_t str_type = H5Tcopy(H5T_C_S1);
+  if (H5Tset_size(str_type, 4) < 0) {
+    fprintf(stderr, "Error setting string type size in create_dac_dataset\n");
+    H5Tclose(str_type);
+    H5Pclose(dcpl);
+    H5Pclose(dapl);
+    return;
+  }
+
+  struct {
+    const char *name;
+    hid_t type;
+  } datasets[] = {
+    {"dac_format", str_type},         {"threshold0", H5T_NATIVE_UINT},
+    {"threshold1", H5T_NATIVE_UINT},  {"threshold2", H5T_NATIVE_UINT},
+    {"threshold3", H5T_NATIVE_UINT},  {"threshold4", H5T_NATIVE_UINT},
+    {"threshold5", H5T_NATIVE_UINT},  {"threshold6", H5T_NATIVE_UINT},
+    {"threshold7", H5T_NATIVE_UINT},  {"preamp", H5T_NATIVE_UINT},
+    {"ikrum", H5T_NATIVE_UINT},       {"shaper", H5T_NATIVE_UINT},
+    {"disc", H5T_NATIVE_UINT},        {"disc_LS", H5T_NATIVE_UINT},
+    {"shaper_test", H5T_NATIVE_UINT}, {"dac_disc_L", H5T_NATIVE_UINT},
+    {"dac_test", H5T_NATIVE_UINT},    {"dac_disc_H", H5T_NATIVE_UINT},
+    {"delay", H5T_NATIVE_UINT},       {"TP_buff_in", H5T_NATIVE_UINT},
+    {"TP_buff_out", H5T_NATIVE_UINT}, {"RPZ", H5T_NATIVE_UINT},
+    {"GND", H5T_NATIVE_UINT},         {"TP_ref", H5T_NATIVE_UINT},
+    {"FBK", H5T_NATIVE_UINT},         {"Cas", H5T_NATIVE_UINT},
+    {"TP_ref_A", H5T_NATIVE_UINT},    {"TP_ref_B", H5T_NATIVE_UINT}};
+
+  size_t num_datasets = sizeof(datasets) / sizeof(datasets[0]);
+  int handle_pos      = 0;
+
+  for (unsigned int i = 0; i < num_chips; i++) {
+    snprintf(chip_group_path, sizeof(chip_group_path), "metadata/Chip%02d", i);
+
+    chip_group =
+      H5Gcreate(file, chip_group_path, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    if (chip_group < 0) {
+      fprintf(stderr, "Error creating group chip%02d in create_dac_dataset\n",
+              i);
+      H5Tclose(str_type);
+      H5Pclose(dcpl);
+      H5Pclose(dapl);
+      return;
+    }
+
+    dataspace = H5Screate_simple(1, dim, max_dim);
+    if (dataspace < 0) {
+      fprintf(stderr, "Error creating dataspace in create_dac_meta_dataset\n");
+      H5Tclose(str_type);
+      H5Pclose(dcpl);
+      H5Pclose(dapl);
+      H5Gclose(chip_group);
+      return;
+    }
+
+    handle_pos = num_datasets * (size_t) i;
+
+    for (size_t j = handle_pos; j < (handle_pos + num_datasets); j++) {
+      // snprintf(dataset_path, sizeof(dataset_path), "%s/%s", chip_group_path,
+      // datasets[j-handle_pos].name);
+
+      snprintf(dataset_path, sizeof(dataset_path), "%s",
+               datasets[j - handle_pos].name);
+
+      dataset =
+        H5Dcreate2(chip_group, dataset_path, datasets[j - handle_pos].type,
+                   dataspace, lcpl, dcpl, dapl);
+      if (dataset < 0) {
+        fprintf(stderr, "Error creating dataset: %s\n", dataset_path);
+        dac_handle[j] = H5I_INVALID_HID;
+        continue;
+      }
+      dac_handle[j] = dataset;
+    }
+
+    H5Sclose(dataspace);
+    H5Gclose(chip_group);
+  }
+
+  H5Tclose(str_type);
+  H5Pclose(dcpl);
+  H5Pclose(dapl);
+}
+
+void close_dataset_handle(hid_t *handle, size_t count)
+{
+  if (!handle)
+    return;
+  for (size_t i = 0; i < count; i++) {
+    if (handle[i] >= 0) {
+      H5Dclose(handle[i]);
+    }
+  }
+}

--- a/src/hdf5_init_meta.c
+++ b/src/hdf5_init_meta.c
@@ -233,8 +233,7 @@ void create_dac_dataset(unsigned int num_chips,
   } else {
     if (H5Pset_chunk(dcpl, 1, chunk_dim) < 0) {
       fprintf(stderr, "Error setting chunking in create_dac_dataset\n");
-      H5Pclose(dcpl);
-      return;
+      goto cleanup;
     }
   }
 
@@ -250,10 +249,7 @@ void create_dac_dataset(unsigned int num_chips,
   hid_t str_type = H5Tcopy(H5T_C_S1);
   if (H5Tset_size(str_type, 4) < 0) {
     fprintf(stderr, "Error setting string type size in create_dac_dataset\n");
-    H5Tclose(str_type);
-    H5Pclose(dcpl);
-    H5Pclose(dapl);
-    return;
+    goto cleanup;
   }
 
   struct {
@@ -286,20 +282,13 @@ void create_dac_dataset(unsigned int num_chips,
     if (chip_group < 0) {
       fprintf(stderr, "Error creating group chip%02d in create_dac_dataset\n",
               i);
-      H5Tclose(str_type);
-      H5Pclose(dcpl);
-      H5Pclose(dapl);
-      return;
+      goto cleanup;
     }
 
     dataspace = H5Screate_simple(1, dim, max_dim);
     if (dataspace < 0) {
       fprintf(stderr, "Error creating dataspace in create_dac_meta_dataset\n");
-      H5Tclose(str_type);
-      H5Pclose(dcpl);
-      H5Pclose(dapl);
-      H5Gclose(chip_group);
-      return;
+      goto cleanup;
     }
 
     handle_pos = num_datasets * (size_t) i;
@@ -329,9 +318,15 @@ void create_dac_dataset(unsigned int num_chips,
     H5Gclose(chip_group);
   }
 
-  H5Tclose(str_type);
-  H5Pclose(dcpl);
-  H5Pclose(dapl);
+cleanup:
+  if (H5Iis_valid(str_type))
+    H5Tclose(str_type);
+  if (H5Iis_valid(dcpl))
+    H5Pclose(dcpl);
+  if (H5Iis_valid(dapl))
+    H5Pclose(dapl);
+  if (H5Iis_valid(chip_group))
+    H5Gclose(chip_group);
 }
 
 void close_dataset_handle(hid_t *handle, size_t count)

--- a/src/hdf5_init_meta.h
+++ b/src/hdf5_init_meta.h
@@ -9,13 +9,11 @@
 #include <stdlib.h>
 #include <time.h>
 
-void create_meta_mq1_fields_dataset(hid_t *file_id,
-                                    hid_t *lcpl_id,
-                                    hid_t *meta_handle);
+void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle);
 
 void create_dac_dataset(unsigned int num_chips,
-                        hid_t *file_id,
-                        hid_t *lcpl_id,
+                        hid_t file,
+                        hid_t lcpl,
                         hid_t *dac_handle);
 
 void close_dataset_handle(hid_t *handle, size_t count);

--- a/src/hdf5_init_meta.h
+++ b/src/hdf5_init_meta.h
@@ -1,0 +1,23 @@
+// clang-format Language: C
+#ifndef HDF5_INIT_META_H
+#define HDF5_INIT_META_H
+
+#include "macros.h"
+#include <hdf5.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void create_meta_mq1_fields_dataset(hid_t *file_id,
+                                    hid_t *lcpl_id,
+                                    hid_t *meta_handle);
+
+void create_dac_dataset(unsigned int num_chips,
+                        hid_t *file_id,
+                        hid_t *lcpl_id,
+                        hid_t *dac_handle);
+
+void close_dataset_handle(hid_t *handle, size_t count);
+
+#endif

--- a/src/hdf5_init_meta.h
+++ b/src/hdf5_init_meta.h
@@ -4,10 +4,7 @@
 
 #include "macros.h"
 #include <hdf5.h>
-#include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
 void create_meta_mq1_fields_dataset(hid_t file, hid_t lcpl, hid_t *meta_handle);
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -29,4 +29,7 @@
 #define MQ1_FIELDS_NUM_FIELDS 19
 
 #define DAC_NUM_FIELDS 28
+
+#define NUM_CHUNKSS_IN_CACHE 32
+
 #endif

--- a/src/macros.h
+++ b/src/macros.h
@@ -34,4 +34,6 @@
 
 #define PRIME_FOR_HASH 521
 
+#define ALIGNMENT_THRESHOLD 512
+
 #endif

--- a/src/macros.h
+++ b/src/macros.h
@@ -30,6 +30,8 @@
 
 #define DAC_NUM_FIELDS 28
 
-#define NUM_CHUNKSS_IN_CACHE 32
+#define NUM_CHUNKS_IN_CACHE 32
+
+#define PRIME_FOR_HASH 521
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -121,3 +121,31 @@ restore:
       current_file, __LINE__);
   }
 }
+
+hid_t bufsize_to_datatype(int dtype)
+{
+  hid_t datatype;
+  switch (dtype) {
+    case 1: {
+      datatype = H5T_STD_U8LE;
+      break;
+    }
+    case 2: {
+      datatype = H5T_STD_U16LE;
+      break;
+    }
+    case 4: {
+      datatype = H5T_STD_U32LE;
+      break;
+    }
+    case 8: {
+      datatype = H5T_STD_U64LE;
+      break;
+    }
+    default: {
+      fprintf(stderr, "Error in datatype, please check input dtype\n");
+      return;
+    }
+  }
+  return datatype;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include <statvfs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -154,6 +154,10 @@ hid_t bufsize_to_datatype(int dtype)
 unsigned long get_filesystem_block_size(const char *path)
 {
   struct statvfs stat;
+  if (!path) {
+    fprintf(stderr, "Null pointer in get_filesystem_block_size\n");
+    return 1;
+  }
 
   if (statvfs(path, &stat) != 0) {
     fprintf(stderr, "statvfs failed\n");

--- a/src/utils.c
+++ b/src/utils.c
@@ -149,3 +149,15 @@ hid_t bufsize_to_datatype(int dtype)
   }
   return datatype;
 }
+
+unsigned long get_filesystem_block_size(const char *path)
+{
+  struct statvfs stat;
+
+  if (statvfs(path, &stat) != 0) {
+    fprintf(stderr, "statvfs failed\n");
+    return 1;
+  }
+
+  return stat.f_bsize;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -144,7 +144,7 @@ hid_t bufsize_to_datatype(int dtype)
     }
     default: {
       fprintf(stderr, "Error in datatype, please check input dtype\n");
-      return;
+      return H5I_INVALID_HID;
     }
   }
   return datatype;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,9 +1,9 @@
 #include "utils.h"
 
-#include <statvfs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/statvfs.h>
 
 const char *only_file_name(const char *absolute_file_path)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,4 +15,6 @@ void header_meta_from_first(FILE *mib_ptr,
                             unsigned int *det_x,
                             unsigned int *det_y,
                             char *pixel_depth);
+
+hid_t bufsize_to_datatype(int dtype);
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,4 +18,6 @@ void header_meta_from_first(FILE *mib_ptr,
                             char *pixel_depth);
 
 hid_t bufsize_to_datatype(int dtype);
+
+unsigned long get_filesystem_block_size(const char *path);
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,5 @@
 // clang-format Language: C
+#include <hdf5.h>
 #include <stdio.h>
 
 #ifndef UTILS_H


### PR DESCRIPTION
# Purpose
This PR is to add code for initializing hdf5 files for appending frames to it later. Here the properties of the h5 files are set. This is just a base for further development. We may want a more flexible set up which allows the user to modify the settings to improve performance but that is not in the scope of this PR.

## hdf5_init
### initialize_file_and_plist
```
void initialize_file_and_plist(char *filename,
                               hid_t *file_id,
                               hid_t *fapl_id,
                               hid_t *fcpl_id)
```
This is to create file creation property list, file access property list and the file itself. This also register the blosc filter to h5 file.
### initialize_lcpl
```
void initialize_lcpl(hid_t *lcpl_id)
```
This is to create lcpl that will be used for different dataset creation.
### create_merlin_dataset
```
void create_merlin_dataset(hid_t *merlin_dataset_id,
                           hid_t *file_id,
                           char *merlin_dataset_name,
                           int dtype,
                           hid_t memspace,
                           hid_t *lcpl_id,
                           size_t dim,
                           hsize_t *frame_dim,
                           unsigned int compression_level,
                           unsigned int shuffle,
                           unsigned int compressor)
```
This is to create the actual dataset that store binary data inside .mib files.

## hdf5_init_meta
### create_meta_mq1_fields_dataset
```
void create_meta_mq1_fields_dataset(hid_t *file_id,
                                    hid_t *lcpl_id,
                                    hid_t *meta_handle);
```
This is to create dataset for each field in MQ1_FIELDS
### create_dac_dataset
```
void create_dac_dataset(unsigned int num_chips,
                        hid_t *file_id,
                        hid_t *lcpl_id,
                        hid_t *dac_handle);
```
This is to create dataset for each field in dac_rx. This is responsible for creating all four dac_rx if the header is mq1_quad
void close_dataset_handle(hid_t *handle, size_t count);