### PR TITLE
Features/compress

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -1,0 +1,135 @@
+#include "config.h"
+#include "framebuffer.h"
+#include "io_header.h"
+#include "macros.h"
+#include "mib_header.h"
+#include "utils.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef HAVE_COMPRESSION
+#include <blosc.h>
+#include <blosc_filter.h>
+#endif
+
+hid_t dcpl_compress(size_t dim,
+                    hsize_t *frame_dim,
+                    unsigned int compression_level,
+                    unsigned int shuffle,
+                    char *compressor)
+{
+  hid_t dcpl                = H5I_INVALID_HID;
+  unsigned int cd_values[7] = {0};
+  if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
+    fprintf(stderr, "Error in creating dcpl\n");
+    return H5I_INVALID_HID;
+  } else {
+    if (H5Pset_chunk(dcpl, dim, frame_dim) < 0) {
+      fprintf(stderr, "Error in H5Pset_chunk\n");
+      return H5I_INVALID_HID;
+    }
+    if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
+      fprintf(stderr, "Error in H5Pset_fill_time\n");
+      return H5I_INVALID_HID;
+    }
+#ifdef HAVE_COMPRESSION
+    char *version = (char *) malloc(sizeof(char) * 512);
+    if (version == NULL) {
+      fprintf(stderr, "malloc for version failed\n");
+      free(version);
+      return H5I_INVALID_HID;
+    }
+    char *date = (char *) malloc(sizeof(char) * 512);
+    if (date == NULL) {
+      fprintf(stderr, "malloc for date failed\n");
+      free(version);
+      free(date);
+      return H5I_INVALID_HID;
+    }
+    cd_values[0] = 0;
+    cd_values[1] = 0;                 // compression_level;
+    cd_values[2] = 0;                 // shuffle;
+    cd_values[3] = 0;                 // blocksize
+    cd_values[4] = compression_level; // unused
+    cd_values[5] = shuffle;           // unused
+    cd_values[6] = blosc_compname_to_compcode(compressor);
+    if (H5Pset_filter(dcpl, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) <
+        0) {
+      fprintf(stderr, "Error in H5Pset_filter\n");
+      return H5I_INVALID_HID;
+    }
+    if (register_blosc(&version, &date) < 0) {
+      fprintf(stderr, "Error in register_blosc\n");
+      free(version);
+      free(date);
+      return H5I_INVALID_HID;
+    } else {
+      printf("Blosc version info: %s (%s)\n", version, date);
+    }
+    free(version);
+    free(date);
+#endif
+  }
+  return dcpl;
+}
+
+int compress_frame(framebuffer *fb,
+                   unsigned int compression_level,
+                   unsigned int shuffle,
+                   char *compressor,
+                   size_t blocksize,
+                   int numinternalthreads)
+{
+  int bufsize = (fb->mq1_header->pixel_depth[1] - '0') * 10 +
+                (fb->mq1_header->pixel_depth[2] - '0');
+  bufsize = bufsize / 8;
+
+  int detx = (int) *(fb->mq1_header->det_x);
+  int dety = (int) *(fb->mq1_header->det_y);
+
+  size_t nbytes = dety * detx * bufsize;
+#ifdef HAVE_COMPRESSION
+  size_t destsize = nbytes + BLOSC_MAX_OVERHEAD;
+  void *dest      = malloc(destsize);
+  if (!dest) {
+    fprintf(stderr, "Error in malloc for dest\n");
+    return -1;
+  }
+
+  cbytes = blosc_compress_ctx(compression_level, shuffle, bufsize, nbytes,
+                              fb->data, dest, destsize, compressor, blocksize,
+                              numinternalthreads);
+
+  if (cbytes < 0) {
+    fprintf(stderr, "Error in blosc_compress\n");
+    free(dest);
+    return -1;
+  }
+  if (cbytes == 0) {
+    fprintf(stderr, "Blosc returned 0 bytes (uncompressible?). Forcing "
+                    "fallback to uncompressed write.\n");
+    cbytes = nbytes;
+    return cbytes;
+  }
+  // for showing compression ratio in each frame, profiling purposes
+  // if (cbytes != 0) {
+  //  printf("compression: %ld -> %d (%.1fx)\n", nbytes, cbytes, (1. * nbytes) /
+  //  cbytes);
+  //}
+
+  free(fb->data);
+  fb->data = malloc(destsize);
+  if (!fb->data) {
+    fprintf(stderr, "Error in malloc for fb->data\n");
+    free(dest);
+    return -1;
+  }
+
+  memcpy(fb->data, dest, cbytes);
+  free(dest);
+  return cbytes;
+#else
+  return nbytes;
+#endif
+}

--- a/src/compress.c
+++ b/src/compress.c
@@ -97,9 +97,9 @@ int compress_frame(framebuffer *fb,
     return -1;
   }
 
-  cbytes = blosc_compress_ctx(compression_level, shuffle, bufsize, nbytes,
-                              fb->data, dest, destsize, compressor, blocksize,
-                              numinternalthreads);
+  int cbytes = blosc_compress_ctx(compression_level, shuffle, bufsize, nbytes,
+                                  fb->data, dest, destsize, compressor,
+                                  blocksize, numinternalthreads);
 
   if (cbytes < 0) {
     fprintf(stderr, "Error in blosc_compress\n");
@@ -110,23 +110,20 @@ int compress_frame(framebuffer *fb,
     fprintf(stderr, "Blosc returned 0 bytes (uncompressible?). Forcing "
                     "fallback to uncompressed write.\n");
     cbytes = nbytes;
+    free(dest);
     return cbytes;
   }
-  // for showing compression ratio in each frame, profiling purposes
-  // if (cbytes != 0) {
-  //  printf("compression: %ld -> %d (%.1fx)\n", nbytes, cbytes, (1. * nbytes) /
-  //  cbytes);
-  //}
 
-  free(fb->data);
-  fb->data = malloc(destsize);
-  if (!fb->data) {
-    fprintf(stderr, "Error in malloc for fb->data\n");
+  void *temp = realloc(fb->data, destsize);
+  if (temp) {
+    fb->data = temp;
+    memcpy(fb->data, dest, cbytes);
+  } else {
+    fprintf(stderr,
+            "Error in realloc for fb->data, fall back on the original data\n");
     free(dest);
-    return -1;
+    return nbytes;
   }
-
-  memcpy(fb->data, dest, cbytes);
   free(dest);
   return cbytes;
 #else

--- a/src/compress.c
+++ b/src/compress.c
@@ -37,19 +37,17 @@ hid_t dcpl_compress(size_t dim,
     char *version = (char *) malloc(sizeof(char) * 512);
     if (version == NULL) {
       fprintf(stderr, "malloc for version failed\n");
-      free(version);
       return H5I_INVALID_HID;
     }
     char *date = (char *) malloc(sizeof(char) * 512);
     if (date == NULL) {
       fprintf(stderr, "malloc for date failed\n");
       free(version);
-      free(date);
       return H5I_INVALID_HID;
     }
     cd_values[0] = 0;
-    cd_values[1] = 0; // unused;
-    cd_values[2] = 0; // unused;
+    cd_values[1] = 0; // unused
+    cd_values[2] = 0; // unused
     cd_values[3] = 0; // blocksize
     cd_values[4] = compression_level;
     cd_values[5] = shuffle;
@@ -57,10 +55,12 @@ hid_t dcpl_compress(size_t dim,
     if (H5Pset_filter(dcpl, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) <
         0) {
       fprintf(stderr, "Error in H5Pset_filter\n");
+      H5Pclose(dcpl);
       return H5I_INVALID_HID;
     }
     if (register_blosc(&version, &date) < 0) {
       fprintf(stderr, "Error in register_blosc\n");
+      H5Pclose(dcpl);
       free(version);
       free(date);
       return H5I_INVALID_HID;

--- a/src/compress.c
+++ b/src/compress.c
@@ -48,11 +48,11 @@ hid_t dcpl_compress(size_t dim,
       return H5I_INVALID_HID;
     }
     cd_values[0] = 0;
-    cd_values[1] = 0;                 // compression_level;
-    cd_values[2] = 0;                 // shuffle;
-    cd_values[3] = 0;                 // blocksize
-    cd_values[4] = compression_level; // unused
-    cd_values[5] = shuffle;           // unused
+    cd_values[1] = 0; // unused;
+    cd_values[2] = 0; // unused;
+    cd_values[3] = 0; // blocksize
+    cd_values[4] = compression_level;
+    cd_values[5] = shuffle;
     cd_values[6] = blosc_compname_to_compcode(compressor);
     if (H5Pset_filter(dcpl, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) <
         0) {

--- a/src/compress.c
+++ b/src/compress.c
@@ -27,21 +27,25 @@ hid_t dcpl_compress(size_t dim,
   } else {
     if (H5Pset_chunk(dcpl, dim, frame_dim) < 0) {
       fprintf(stderr, "Error in H5Pset_chunk\n");
+      H5Pclose(dcpl);
       return H5I_INVALID_HID;
     }
     if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
       fprintf(stderr, "Error in H5Pset_fill_time\n");
+      H5Pclose(dcpl);
       return H5I_INVALID_HID;
     }
 #ifdef HAVE_COMPRESSION
     char *version = (char *) malloc(sizeof(char) * 512);
     if (version == NULL) {
       fprintf(stderr, "malloc for version failed\n");
+      H5Pclose(dcpl);
       return H5I_INVALID_HID;
     }
     char *date = (char *) malloc(sizeof(char) * 512);
     if (date == NULL) {
       fprintf(stderr, "malloc for date failed\n");
+      H5Pclose(dcpl);
       free(version);
       return H5I_INVALID_HID;
     }

--- a/src/compress.h
+++ b/src/compress.h
@@ -1,0 +1,18 @@
+// clang-format Language: C
+#ifndef COMPRESS_H
+#define COMPRESS_H
+
+hid_t dcpl_compress(size_t dim,
+                    hsize_t *frame_dim,
+                    unsigned int compression_level,
+                    unsigned int shuffle,
+                    char *compressor);
+
+int compress_frame(framebuffer *fb,
+                   unsigned int compression_level,
+                   unsigned int shuffle,
+                   char *compressor,
+                   size_t blocksize,
+                   int numinternalthreads);
+
+#endif

--- a/src/hdf5_init.c
+++ b/src/hdf5_init.c
@@ -55,27 +55,13 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
                            char *merlin_dataset_name,
                            int dtype,
                            hid_t memspace,
+                           hid_t dcpl,
                            hid_t lcpl,
                            size_t dim,
                            hsize_t *frame_dim)
 {
-  hid_t dcpl     = H5I_INVALID_HID;
   hid_t dapl     = H5I_INVALID_HID;
   hid_t datatype = H5I_INVALID_HID;
-
-  if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
-    fprintf(stderr, "Error in creating dcpl\n");
-    goto cleanup;
-  } else {
-    if (H5Pset_chunk(dcpl, dim, frame_dim) < 0) {
-      fprintf(stderr, "Error in H5Pset_chunk\n");
-      goto cleanup;
-    }
-    if (H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0) {
-      fprintf(stderr, "Error in H5Pset_fill_time\n");
-      goto cleanup;
-    }
-  }
 
   if ((dapl = H5Pcreate(H5P_DATASET_ACCESS)) == H5I_INVALID_HID) {
     fprintf(stderr, "Error in creating dapl_id\n");

--- a/src/hdf5_init.h
+++ b/src/hdf5_init.h
@@ -17,6 +17,7 @@ void create_merlin_dataset(hid_t *merlin_dataset_id,
                            char *merlin_dataset_name,
                            int dtype,
                            hid_t memspace,
+                           hid_t dcpl,
                            hid_t lcpl,
                            size_t dim,
                            hsize_t *frame_dim);


### PR DESCRIPTION
Add logics to use blosc compression with c-blosc and hdf5-blosc. Rely on autotools to detect and create macros in config.h to indicate whether c-blosc and hdf5-blosc library exist.

```
hid_t dcpl_compress(size_t dim,
                    hsize_t *frame_dim,
                    unsigned int compression_level,
                    unsigned int shuffle,
                    char *compressor)
```
This returns a dcpl for dataset. If compression is enabled then it will register the filter, otherwise just return a dcpl with set_chunk and fill_time.
```

 int compress_frame(framebuffer *fb,
                    unsigned int compression_level,
                    unsigned int shuffle,
                    char *compressor,
                    size_t blocksize,
                    int numinternalthreads)
```
This returns the bytesize if the raw data after compression. If compression is enabled then it will compress the data and return the size, otherwise just return the size of the raw data.