### PR TITLE
Add tests and GitHub Action for Python builds

### DIFF
--- a/.github/workflows/test-build-c.yml
+++ b/.github/workflows/test-build-c.yml
@@ -69,7 +69,6 @@ jobs:
         with:
           name: ${{ matrix.artefact-name }}
           path: /tmp/${{ matrix.artefact-name }}.tar.gz
-          retention-days: 7
           compression-level: 0
 
   # test gcc 7-14

--- a/.github/workflows/test-build-c.yml
+++ b/.github/workflows/test-build-c.yml
@@ -23,17 +23,6 @@ jobs:
     container: gcc:7
     name: Build HDF5 - ${{ matrix.name }}
     steps:
-      - name: Use archive repositories for Debian Buster
-        run: |
-          sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list
-          sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list
-          sed -i '/buster-updates/d' /etc/apt/sources.list
-
-      - name: Install build dependencies
-        run: |
-          apt-get update
-          apt-get install -y wget
-
       - name: Cache HDF5 build
         id: cache-hdf5
         uses: actions/cache@v4
@@ -47,6 +36,12 @@ jobs:
       - name: Download and build HDF5
         if: steps.cache-hdf5.outputs.cache-hit != 'true'
         run: |
+          # use archive repositories for Debian Buster
+          sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list
+          sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list
+          sed -i '/buster-updates/d' /etc/apt/sources.list
+          apt-get update && apt-get install -y wget
+
           # use HDF5 1.14.x
           wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz
           tar -xzf hdf5-1.14.6.tar.gz

--- a/.github/workflows/test-build-python.yml
+++ b/.github/workflows/test-build-python.yml
@@ -1,0 +1,116 @@
+name: Python Build Tests
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  # build hdf5 library for python tests
+  build-hdf5:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container: gcc:7
+    name: Build HDF5
+    steps:
+      - name: Cache HDF5 build
+        id: cache-hdf5
+        uses: actions/cache@v4
+        with:
+          path: /tmp/hdf5-python
+          key: hdf5-1.14.6-python-gcc7-${{ runner.os }}-v1
+          restore-keys: |
+            hdf5-1.14.6-python-gcc7-${{ runner.os }}-
+            hdf5-1.14.6-python-gcc7-
+
+      - name: Download and build HDF5
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        run: |
+          # use archive repositories for Debian Buster
+          sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list
+          sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list
+          sed -i '/buster-updates/d' /etc/apt/sources.list
+          apt-get update && apt-get install -y wget
+
+          # use HDF5 1.14.x
+          wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz
+          tar -xzf hdf5-1.14.6.tar.gz
+          cd hdf5-1.14.6
+
+          # configure for /opt/hdf5
+          ./configure --prefix=/opt/hdf5
+          make -j$(nproc)
+
+          # staged for artefact
+          make install DESTDIR=/tmp/hdf5-python
+
+      - name: Create tarball artefact
+        run: |
+          cd /tmp/hdf5-python
+          tar -czf /tmp/hdf5-python.tar.gz .
+
+      - name: Upload HDF5 artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hdf5-python
+          path: /tmp/hdf5-python.tar.gz
+          compression-level: 0
+
+  # test python installation methods
+  test-python:
+    needs: build-hdf5
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      HDF5_ROOT: /opt/hdf5
+      LD_LIBRARY_PATH: /opt/hdf5/lib
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        install-method: ["standard"]
+        include:
+          # add editable and pipx test for lowest-supported Python
+          - python-version: "3.10"
+            install-method: "editable"
+          - python-version: "3.10"
+            install-method: "pipx"
+    name: Python ${{ matrix.python-version }} - ${{ matrix.install-method }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool
+          # install pipx only when needed
+          if [[ "${{ matrix.install-method }}" == "pipx" ]]; then
+            sudo apt-get install -y pipx
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download HDF5 artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: hdf5-python
+
+      - name: Install HDF5
+        run: |
+          sudo tar -xzf hdf5-python.tar.gz -C /
+
+      - name: Run build test
+        run: |
+          ./tests/test_build/test_build_python.sh --only ${{ matrix.install-method }}
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-py${{ matrix.python-version }}-${{ matrix.install-method }}
+          path: tests/test_build/logs/
+          retention-days: 7

--- a/python/src/mib2h5/cli.py
+++ b/python/src/mib2h5/cli.py
@@ -128,7 +128,7 @@ def main() -> int:
     # validate input files exist
     missing_files = []
     for filepath in args.input_files:
-        if not Path(filepath).exists:
+        if not Path(filepath).exists():
             missing_files.append(filepath)
 
     if missing_files:

--- a/tests/test_build/test_build_python.sh
+++ b/tests/test_build/test_build_python.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# constants
+readonly script_dir="$(dirname "$(readlink -f "$0")")"
+readonly project_root="$(cd "$script_dir/../.." && pwd)"
+readonly python_dir="$project_root/python"
+readonly log_dir="$script_dir/logs"
+
+# version requirements
+readonly min_python_major=3
+readonly min_python_minor=10
+
+total_tests=0
+passed_tests=0
+failed_tests=0
+skipped_tests=0
+test_filter="all"
+
+cleanup() {
+    cd "$project_root" 2>/dev/null || true
+    if [[ -f Makefile ]]; then
+        make distclean >/dev/null 2>&1 || true
+    fi
+
+    # clean python build artefacts
+    rm -rf "$python_dir/build" 2>/dev/null || true
+    rm -rf "$python_dir/dist" 2>/dev/null || true
+    rm -rf "$python_dir/src/mib2h5.egg-info" 2>/dev/null || true
+    rm -rf "$python_dir/src/mib2h5/_wrapper.c" 2>/dev/null || true
+    rm -rf "$python_dir/src/mib2h5/_wrapper."*.so 2>/dev/null || true
+    rm -rf "$python_dir/__pycache__" 2>/dev/null || true
+    rm -rf "$python_dir/src/mib2h5/__pycache__" 2>/dev/null || true
+
+    # clean pipx installation
+    if command -v pipx >/dev/null 2>&1; then
+        pipx uninstall mib2h5 >/dev/null 2>&1 || true
+    fi
+}
+
+# register cleanup on exit
+trap cleanup EXIT
+
+check_prerequisites() {
+    local errors=0
+
+    # check hdf5_root is set
+    if [[ -z "${HDF5_ROOT:-}" ]]; then
+        echo "ERROR: HDF5_ROOT environment variable not set"
+        errors=$((errors + 1))
+    elif [[ ! -d "${HDF5_ROOT}" ]]; then
+        echo "ERROR: HDF5_ROOT directory does not exist: ${HDF5_ROOT}"
+        errors=$((errors + 1))
+    fi
+
+    # check python version
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: python3 not found"
+        errors=$((errors + 1))
+    else
+        local python_version
+        python_version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        local major minor
+        IFS='.' read -r major minor <<< "$python_version"
+        if [[ "$major" -lt $min_python_major ]] || [[ "$major" -eq $min_python_major && "$minor" -lt $min_python_minor ]]; then
+            echo "ERROR: Python $min_python_major.$min_python_minor+ required, found $python_version"
+            errors=$((errors + 1))
+        fi
+    fi
+
+    return "$errors"
+}
+
+# check if test should be run based on filter
+should_run_test() {
+    local test_name="$1"
+    local filter="$2"
+    [[ "$filter" == "all" ]] || [[ "$filter" == "$test_name" ]]
+}
+
+# run test in an isolated environment
+run_isolated_test() {
+    local test_name="$1"
+    local install_method="$2"
+
+    total_tests=$((total_tests + 1))
+    echo -n "Test: $test_name... "
+
+    # run in subshell for complete isolation
+    if (
+        # clear environment variables that might interfere
+        unset PYTHONPATH
+        unset PIP_CONFIG_FILE
+        unset PIP_CACHE_DIR
+
+        # set required environment
+        export LD_LIBRARY_PATH="${HDF5_ROOT}/lib:${LD_LIBRARY_PATH:-}"
+
+        # run the actual test
+        run_test_internal "$test_name" "$install_method"
+    ); then
+        passed_tests=$((passed_tests + 1))
+    else
+        failed_tests=$((failed_tests + 1))
+    fi
+}
+
+# actual test runner
+run_test_internal() {
+    local test_name="$1"
+    local install_method="$2"
+    local log_file="${log_dir}/${test_name}.log"
+
+    # create temp directory for virtual environment
+    local temp_dir
+    temp_dir=$(mktemp -d /tmp/mib2h5_test_XXXXXX)
+    local venv_dir="$temp_dir/venv"
+
+    # ensure temp directory cleanup
+    trap "rm -rf '$temp_dir'" RETURN
+
+    # clean previous build
+    cleanup
+
+    # create virtual environment
+    if ! python3 -m venv "$venv_dir" >>"$log_file" 2>&1; then
+        echo "FAIL (venv creation)"
+        return 1
+    fi
+
+    # use venv's pip directly (no need to activate in subshell)
+    local pip_cmd="$venv_dir/bin/pip"
+    local python_cmd="$venv_dir/bin/python"
+
+    # upgrade pip and install build dependencies
+    if ! "$pip_cmd" install --upgrade pip 'setuptools>=77.0' wheel 'cython>=3' >>"$log_file" 2>&1; then
+        echo "FAIL (pip dependencies)"
+        return 1
+    fi
+
+    # change to python directory
+    cd "$python_dir"
+
+    # install package based on method
+    case "$install_method" in
+        "standard")
+            if ! "$pip_cmd" install . >>"$log_file" 2>&1; then
+                local error_line
+                error_line=$(grep -E "error:|ERROR:|FAILED" "$log_file" | tail -1 | head -c 60)
+                if [[ -n "$error_line" ]]; then
+                    echo "FAIL (install: $error_line...)"
+                else
+                    echo "FAIL (install)"
+                fi
+                return 1
+            fi
+            ;;
+        "editable")
+            if ! "$pip_cmd" install -e . >>"$log_file" 2>&1; then
+                local error_line
+                error_line=$(grep -E "error:|ERROR:|FAILED" "$log_file" | tail -1 | head -c 60)
+                if [[ -n "$error_line" ]]; then
+                    echo "FAIL (editable install: $error_line...)"
+                else
+                    echo "FAIL (editable install)"
+                fi
+                return 1
+            fi
+            ;;
+        "pipx")
+            # for pipx, we use the global pipx command
+            export PIPX_DEFAULT_PYTHON=$(which python3)
+            if ! pipx install . --verbose >>"$log_file" 2>&1; then
+                local error_line
+                error_line=$(grep -E "error:|ERROR:|FAILED" "$log_file" | tail -1 | head -c 60)
+                if [[ -n "$error_line" ]]; then
+                    echo "FAIL (pipx install: $error_line...)"
+                else
+                    echo "FAIL (pipx install)"
+                fi
+                return 1
+            fi
+            ;;
+        *)
+            echo "FAIL (unknown install method)"
+            return 1
+            ;;
+    esac
+
+    # test cli version
+    local mib2h5_cmd
+    if [[ "$install_method" == "pipx" ]]; then
+        mib2h5_cmd="mib2h5"
+    else
+        mib2h5_cmd="$venv_dir/bin/mib2h5"
+    fi
+
+    if ! "$mib2h5_cmd" --version >>"$log_file" 2>&1; then
+        echo "FAIL (--version)"
+        return 1
+    fi
+
+    # test cli help
+    if ! "$mib2h5_cmd" --help >>"$log_file" 2>&1; then
+        echo "FAIL (--help)"
+        return 1
+    fi
+
+    # test python import (skip for pipx as it uses isolated environment)
+    if [[ "$install_method" != "pipx" ]]; then
+        if ! "$python_cmd" -c "import mib2h5; print('Import successful')" >>"$log_file" 2>&1; then
+            echo "FAIL (import)"
+            return 1
+        fi
+    fi
+
+    # cleanup pipx installation
+    if [[ "$install_method" == "pipx" ]]; then
+        pipx uninstall mib2h5 >>"$log_file" 2>&1 || true
+    fi
+
+    echo "PASS"
+    return 0
+}
+
+main() {
+    # parse arguments
+    case "${1:-}" in
+        --clean)
+            echo "Cleaning build artefacts..."
+            cleanup
+            rm -rf "$log_dir"
+            echo "Done"
+            exit 0
+            ;;
+        --list)
+            echo "Require setting HDF5_ROOT to the HDF5 installation"
+            echo
+            echo "Available tests:"
+            echo "  standard  - Standard pip install"
+            echo "  editable  - Editable/development install"
+            echo "  pipx      - pipx install"
+            echo ""
+            echo "Usage:"
+            echo "  $0              # Run all tests"
+            echo "  $0 --only TEST  # Run specific test"
+            echo "  $0 --list       # Show this list"
+            echo "  $0 --clean      # Clean build artefacts"
+            exit 0
+            ;;
+        --only)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --only requires a test name"
+                echo "Use --list to see available tests"
+                exit 1
+            fi
+            test_filter="$2"
+            ;;
+        *)
+            if [[ -n "${1:-}" ]]; then
+                echo "Unknown option: $1"
+                echo "Use --list to see available options"
+                exit 1
+            fi
+            ;;
+    esac
+
+    echo "=== Python Build Tests ==="
+    if [[ "$test_filter" != "all" ]]; then
+        echo "Running only: $test_filter"
+    fi
+    echo "HDF5_ROOT: ${HDF5_ROOT:-not set}"
+    echo
+
+    # check prerequisites
+    echo -n "Prerequisites check... "
+    if check_prerequisites >/dev/null 2>&1; then
+        echo "OK"
+    else
+        echo "FAIL"
+        # re-run to show stdout
+        check_prerequisites
+        exit 1
+    fi
+    echo
+
+    # create log directory
+    mkdir -p "$log_dir"
+
+    # test 1: standard install
+    if should_run_test "standard" "$test_filter"; then
+        run_isolated_test "standard_install" "standard"
+    fi
+
+    # test 2: editable install
+    if should_run_test "editable" "$test_filter"; then
+        run_isolated_test "editable_install" "editable"
+    fi
+
+    # test 3: pipx install
+    if should_run_test "pipx" "$test_filter"; then
+        if command -v pipx >/dev/null 2>&1; then
+            run_isolated_test "pipx_install" "pipx"
+        else
+            skipped_tests=$((skipped_tests + 1))
+            echo "Test: pipx_install... SKIP (pipx not found)"
+        fi
+    fi
+
+    # summary
+    echo
+
+    # handle case where no tests ran
+    if [[ $total_tests -eq 0 ]] && [[ $skipped_tests -gt 0 ]]; then
+        echo "Tests run: 0, Skipped: $skipped_tests"
+        echo "No tests were run. Check --list for available tests."
+        exit 0
+    fi
+
+    # normal summary
+    echo "Tests: $passed_tests/$total_tests passed"
+    if [[ $skipped_tests -gt 0 ]]; then
+        echo "Skipped: $skipped_tests"
+    fi
+
+    if [[ $failed_tests -eq 0 ]]; then
+        if [[ $total_tests -gt 0 ]]; then
+            echo "All tests passed!"
+        fi
+        exit 0
+    else
+        echo "Failed: $failed_tests"
+        echo "Check logs in: $log_dir"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
This PR adds a bash script to test different mechanisms of building the mib2h5 Python wrapper.  Those mechanisms are:
- `standard` (pip install)
- `editable` (pip install -e)
- `pipx` (via pipx)

Following the same spirit as in `test_build_c.sh`, the usage can be seen by `test_build_python.sh --list`.

A GitHub Action is also added to use the above script to test whether building the Python wrapper is successful. The action tests Python version from 3.10 to 3.13 for now.
